### PR TITLE
feat: add trivy-scan-notify and trivy-sbom-notify actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v7.1.0] - 2026-04-21
+### Added
+- trivy-scan-notify
+  - New composite action wrapping `aquasecurity/trivy-action` for image, filesystem and IaC-config scans
+  - Uploads SARIF to GitHub Code Scanning and archives it as a 14-day workflow artifact
+  - Notifies on Mattermost with parsed CRITICAL/HIGH/MEDIUM finding counts
+  - External actions SHA-pinned per the iMio security référentiel (§5.5)
+- trivy-sbom-notify
+  - New composite action generating a CycloneDX (or SPDX) SBOM for a container image
+  - Uploads the SBOM as a workflow artifact (90-day retention by default) and notifies on Mattermost
+
 ## [v7.0.1] - 2026-04-21
 ### Changed
 - mattermost-notify

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ This repository hosts a set of github actions we use to deploy our apps.
     - [k8s-update-tag](#k8s-update-tag)
       - [Inputs](#inputs-10)
       - [Example of usage](#example-of-usage-11)
+    - [trivy-scan-notify](#trivy-scan-notify)
+      - [Inputs](#inputs-11)
+      - [Example of usage](#example-of-usage-12)
+    - [trivy-sbom-notify](#trivy-sbom-notify)
+      - [Inputs](#inputs-12)
+      - [Example of usage](#example-of-usage-13)
   - [Contribute](#contribute)
     - [Release](#release)
 
@@ -337,6 +343,118 @@ Update a component tag in Kubernetes values file and commit to repository. This 
     REPO_URL: github.com/myorg/k8s-configs.git
     TARGET_BRANCH: main
     VALUES_FILE_PATH: staging/myapp/values-dev.yaml
+```
+
+---
+### trivy-scan-notify
+
+Run a [Trivy](https://github.com/aquasecurity/trivy) scan (container image, filesystem or IaC config), upload the SARIF report to GitHub Code Scanning, archive it as a workflow artifact, and optionally notify via Mattermost with parsed severity counts.
+
+External actions are pinned by SHA as required by the iMio security référentiel (§5.5 CI/CD).
+
+> [!IMPORTANT]
+> The calling workflow must grant `permissions: security-events: write` for the SARIF upload to Code Scanning to succeed. On **private** repositories, GitHub Advanced Security must be enabled.
+
+#### Inputs
+
+| name                   | required | type    | default                   | description |
+| ---------------------- | -------- | ------- | ------------------------- | ----------- |
+| SCAN_TYPE              |   yes    | string  |                           | One of `image`, `fs`, `config` |
+| IMAGE_REF              |   cond.  | string  |                           | Image reference to scan (required when `SCAN_TYPE=image`) |
+| SCAN_REF               |   no     | string  | `"."`                     | Filesystem path (used when `SCAN_TYPE` is `fs` or `config`) |
+| SEVERITY               |   no     | string  | `"HIGH,CRITICAL"`         | Comma-separated severity levels to report |
+| SCANNERS               |   no     | string  | *(per-type default)*      | Trivy scanners. If empty: `image`→`vuln,secret,misconfig`, `fs`→`vuln,secret`, `config`→`secret,misconfig` |
+| EXIT_CODE              |   no     | string  | `"1"`                     | Exit code when findings match `SEVERITY` (set to `"0"` during bootstrap) |
+| IGNORE_UNFIXED         |   no     | string  | `"true"`                  | Ignore vulnerabilities without a known fix |
+| TRIVYIGNORES           |   no     | string  | `".trivyignore"`          | Path to a `.trivyignore` file |
+| UPLOAD_SARIF           |   no     | string  | `"true"`                  | Upload SARIF to GitHub Code Scanning |
+| SARIF_CATEGORY         |   no     | string  | `"trivy-<SCAN_TYPE>"`     | Code Scanning category for split results |
+| TRIVY_USERNAME         |   no     | string  |                           | Username for a private image registry |
+| TRIVY_PASSWORD         |   no     | string  |                           | Password for a private image registry |
+| GITHUB_TOKEN           |   no     | string  |                           | Pass `secrets.GITHUB_TOKEN` to avoid Trivy DB rate-limits |
+| MATTERMOST_WEBHOOK_URL |   no     | string  |                           | Webhook URL to send notifications on Mattermost |
+
+#### Example of usage
+
+```yaml
+name: Trivy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write  # required to upload SARIF
+
+jobs:
+  trivy-fs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: imio/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: fs
+          SCAN_REF: .
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+
+  trivy-iac:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: imio/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: config
+          SCAN_REF: .
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+
+  trivy-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - run: docker build -t ${{ github.repository }}:${{ github.sha }} .
+      - uses: imio/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: ${{ github.repository }}:${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+```
+
+---
+### trivy-sbom-notify
+
+Generate a CycloneDX (or SPDX) SBOM for a container image with Trivy, upload it as a workflow artifact, and optionally notify on Mattermost. This action does not block the pipeline.
+
+#### Inputs
+
+| name                   | required | type    | default                         | description |
+| ---------------------- | -------- | ------- | ------------------------------- | ----------- |
+| IMAGE_REF              |   yes    | string  |                                 | Full registry-qualified image reference |
+| FORMAT                 |   no     | string  | `"cyclonedx"`                   | `cyclonedx` or `spdx-json` |
+| OUTPUT                 |   no     | string  | `"sbom.cdx.json"`               | Output file path |
+| ARTIFACT_NAME          |   no     | string  | `"sbom-${{ github.sha }}"`      | Name of the workflow artifact |
+| RETENTION_DAYS         |   no     | string  | `"90"`                          | Artifact retention in days |
+| TRIVY_USERNAME         |   no     | string  |                                 | Username for a private image registry |
+| TRIVY_PASSWORD         |   no     | string  |                                 | Password for a private image registry |
+| GITHUB_TOKEN           |   no     | string  |                                 | Pass `secrets.GITHUB_TOKEN` to avoid rate-limits |
+| MATTERMOST_WEBHOOK_URL |   no     | string  |                                 | Webhook URL to send notifications on Mattermost |
+
+#### Example of usage
+
+```yaml
+jobs:
+  sbom:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: trivy-image
+    steps:
+      - uses: imio/gha/trivy-sbom-notify@v7
+        with:
+          IMAGE_REF: registry.example.org/${{ github.repository }}:${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
 ```
 
 ## Contribute

--- a/trivy-sbom-notify/action.yml
+++ b/trivy-sbom-notify/action.yml
@@ -1,0 +1,78 @@
+name: Trivy SBOM and notify
+description: Generate a CycloneDX (or SPDX) SBOM for a container image with Trivy, upload it as a workflow artifact, and notify on Mattermost
+inputs:
+  IMAGE_REF:
+    description: 'Full registry-qualified image reference to analyse (e.g. registry.example/org/app:sha)'
+    required: true
+  FORMAT:
+    description: 'SBOM format: cyclonedx or spdx-json'
+    required: false
+    default: 'cyclonedx'
+  OUTPUT:
+    description: 'Output file path for the generated SBOM'
+    required: false
+    default: 'sbom.cdx.json'
+  ARTIFACT_NAME:
+    description: 'Name of the workflow artifact that will contain the SBOM'
+    required: false
+    default: 'sbom-${{ github.sha }}'
+  RETENTION_DAYS:
+    description: 'Artifact retention in days'
+    required: false
+    default: '90'
+  TRIVY_USERNAME:
+    description: 'Username for a private image registry (optional)'
+    required: false
+    default: ''
+  TRIVY_PASSWORD:
+    description: 'Password for a private image registry (optional)'
+    required: false
+    default: ''
+  GITHUB_TOKEN:
+    description: 'GitHub token forwarded to Trivy as TRIVY_GITHUB_TOKEN to avoid API rate-limiting. Pass secrets.GITHUB_TOKEN from the calling workflow.'
+    required: false
+    default: ''
+  MATTERMOST_WEBHOOK_URL:
+    description: 'Webhook URL for Mattermost notification. If empty, notification is skipped.'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Generate SBOM with Trivy
+      id: sbom
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+      with:
+        scan-type: image
+        image-ref: ${{ inputs.IMAGE_REF }}
+        format: ${{ inputs.FORMAT }}
+        output: ${{ inputs.OUTPUT }}
+        exit-code: '0'
+        cache: 'true'
+      env:
+        TRIVY_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        TRIVY_USERNAME: ${{ inputs.TRIVY_USERNAME }}
+        TRIVY_PASSWORD: ${{ inputs.TRIVY_PASSWORD }}
+
+    - name: Upload SBOM artifact
+      if: always() && hashFiles(inputs.OUTPUT) != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: ${{ inputs.ARTIFACT_NAME }}
+        path: ${{ inputs.OUTPUT }}
+        retention-days: ${{ inputs.RETENTION_DAYS }}
+
+    - name: Notify on Mattermost
+      if: always()
+      uses: imio/gha/mattermost-notify@v7
+      with:
+        MATTERMOST_WEBHOOK_URL: ${{ inputs.MATTERMOST_WEBHOOK_URL }}
+        STATUS: ${{ steps.sbom.outcome == 'success' && 'success' || 'failure' }}
+        TITLE: "Trivy SBOM"
+        BODY: |
+          **Repository:** [${{ github.repository }}](${{ github.server_url }}/${{ github.repository }})
+          **Branch:** ${{ github.ref_name }}
+          **Commit:** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          **Image:** ${{ inputs.IMAGE_REF }}
+          **Format:** ${{ inputs.FORMAT }}
+          **Artifact:** ${{ inputs.ARTIFACT_NAME }}

--- a/trivy-sbom-notify/action.yml
+++ b/trivy-sbom-notify/action.yml
@@ -55,6 +55,7 @@ runs:
         TRIVY_PASSWORD: ${{ inputs.TRIVY_PASSWORD }}
 
     - name: Resolve artifact name
+      if: always()
       id: artifact
       shell: bash
       run: |

--- a/trivy-sbom-notify/action.yml
+++ b/trivy-sbom-notify/action.yml
@@ -15,7 +15,7 @@ inputs:
   ARTIFACT_NAME:
     description: 'Name of the workflow artifact that will contain the SBOM'
     required: false
-    default: 'sbom-${{ github.sha }}'
+    default: ''
   RETENTION_DAYS:
     description: 'Artifact retention in days'
     required: false
@@ -54,11 +54,21 @@ runs:
         TRIVY_USERNAME: ${{ inputs.TRIVY_USERNAME }}
         TRIVY_PASSWORD: ${{ inputs.TRIVY_PASSWORD }}
 
+    - name: Resolve artifact name
+      id: artifact
+      shell: bash
+      run: |
+        name="${{ inputs.ARTIFACT_NAME }}"
+        if [ -z "$name" ]; then
+          name="sbom-${GITHUB_SHA}"
+        fi
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+
     - name: Upload SBOM artifact
       if: always() && hashFiles(inputs.OUTPUT) != ''
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
-        name: ${{ inputs.ARTIFACT_NAME }}
+        name: ${{ steps.artifact.outputs.name }}
         path: ${{ inputs.OUTPUT }}
         retention-days: ${{ inputs.RETENTION_DAYS }}
 
@@ -75,4 +85,4 @@ runs:
           **Commit:** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
           **Image:** ${{ inputs.IMAGE_REF }}
           **Format:** ${{ inputs.FORMAT }}
-          **Artifact:** ${{ inputs.ARTIFACT_NAME }}
+          **Artifact:** ${{ steps.artifact.outputs.name }}

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -1,0 +1,200 @@
+name: Trivy scan and notify
+description: Run a Trivy scan (image, filesystem or IaC config), upload SARIF to Code Scanning, and notify on Mattermost with parsed severity counts
+inputs:
+  SCAN_TYPE:
+    description: 'Trivy scan type: image, fs or config'
+    required: true
+  IMAGE_REF:
+    description: 'Image reference to scan (required when SCAN_TYPE=image)'
+    required: false
+    default: ''
+  SCAN_REF:
+    description: 'Filesystem path to scan (used when SCAN_TYPE=fs or config)'
+    required: false
+    default: '.'
+  SEVERITY:
+    description: 'Comma-separated severity levels to report'
+    required: false
+    default: 'HIGH,CRITICAL'
+  SCANNERS:
+    description: 'Comma-separated list of Trivy scanners. If empty, a sensible default is picked per SCAN_TYPE (image=vuln,secret,misconfig ; fs=vuln,secret ; config=secret,misconfig)'
+    required: false
+    default: ''
+  EXIT_CODE:
+    description: 'Exit code to use when findings match SEVERITY (set to 0 during bootstrap to only report)'
+    required: false
+    default: '1'
+  IGNORE_UNFIXED:
+    description: 'Ignore vulnerabilities without a known fix'
+    required: false
+    default: 'true'
+  TRIVYIGNORES:
+    description: 'Path to a .trivyignore file (empty to disable)'
+    required: false
+    default: '.trivyignore'
+  UPLOAD_SARIF:
+    description: 'Upload the SARIF report to GitHub Code Scanning (requires security-events: write in the calling workflow, and GHAS on private repos)'
+    required: false
+    default: 'true'
+  SARIF_CATEGORY:
+    description: 'Category used when uploading SARIF (defaults to trivy-<SCAN_TYPE>)'
+    required: false
+    default: ''
+  TRIVY_USERNAME:
+    description: 'Username for a private image registry (optional)'
+    required: false
+    default: ''
+  TRIVY_PASSWORD:
+    description: 'Password for a private image registry (optional)'
+    required: false
+    default: ''
+  GITHUB_TOKEN:
+    description: 'GitHub token forwarded to Trivy as TRIVY_GITHUB_TOKEN to avoid API rate-limiting. Pass secrets.GITHUB_TOKEN from the calling workflow.'
+    required: false
+    default: ''
+  MATTERMOST_WEBHOOK_URL:
+    description: 'Webhook URL for Mattermost notification. If empty, notification is skipped.'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout
+      if: inputs.SCAN_TYPE != 'image'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+    - name: Resolve default scanners
+      id: defaults
+      env:
+        SCAN_TYPE: ${{ inputs.SCAN_TYPE }}
+        SCANNERS_IN: ${{ inputs.SCANNERS }}
+        SARIF_CATEGORY_IN: ${{ inputs.SARIF_CATEGORY }}
+      shell: bash
+      run: |
+        if [ -n "$SCANNERS_IN" ]; then
+          SCANNERS_EFFECTIVE="$SCANNERS_IN"
+        else
+          case "$SCAN_TYPE" in
+            image)  SCANNERS_EFFECTIVE="vuln,secret,misconfig" ;;
+            fs)     SCANNERS_EFFECTIVE="vuln,secret" ;;
+            config) SCANNERS_EFFECTIVE="secret,misconfig" ;;
+            *)
+              echo "::error::Invalid SCAN_TYPE '$SCAN_TYPE' (must be image, fs or config)"
+              exit 2
+              ;;
+          esac
+        fi
+        if [ "$SCAN_TYPE" = "image" ] && [ -z "${{ inputs.IMAGE_REF }}" ]; then
+          echo "::error::IMAGE_REF is required when SCAN_TYPE=image"
+          exit 2
+        fi
+        if [ -n "$SARIF_CATEGORY_IN" ]; then
+          SARIF_CATEGORY_EFFECTIVE="$SARIF_CATEGORY_IN"
+        else
+          SARIF_CATEGORY_EFFECTIVE="trivy-$SCAN_TYPE"
+        fi
+        echo "scanners=$SCANNERS_EFFECTIVE" >> "$GITHUB_OUTPUT"
+        echo "sarif_category=$SARIF_CATEGORY_EFFECTIVE" >> "$GITHUB_OUTPUT"
+        echo "sarif_file=trivy-$SCAN_TYPE.sarif" >> "$GITHUB_OUTPUT"
+        echo "json_file=trivy-$SCAN_TYPE.json" >> "$GITHUB_OUTPUT"
+
+    - name: Trivy scan (SARIF)
+      id: scan
+      continue-on-error: true
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+      with:
+        scan-type: ${{ inputs.SCAN_TYPE }}
+        image-ref: ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || '' }}
+        scan-ref: ${{ inputs.SCAN_TYPE == 'image' && '' || inputs.SCAN_REF }}
+        format: sarif
+        output: ${{ steps.defaults.outputs.sarif_file }}
+        severity: ${{ inputs.SEVERITY }}
+        scanners: ${{ steps.defaults.outputs.scanners }}
+        exit-code: ${{ inputs.EXIT_CODE }}
+        ignore-unfixed: ${{ inputs.IGNORE_UNFIXED }}
+        trivyignores: ${{ inputs.TRIVYIGNORES }}
+        cache: 'true'
+      env:
+        TRIVY_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        TRIVY_USERNAME: ${{ inputs.TRIVY_USERNAME }}
+        TRIVY_PASSWORD: ${{ inputs.TRIVY_PASSWORD }}
+
+    - name: Trivy scan (JSON, non-blocking, for counts)
+      if: always()
+      id: scan_json
+      continue-on-error: true
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+      with:
+        scan-type: ${{ inputs.SCAN_TYPE }}
+        image-ref: ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || '' }}
+        scan-ref: ${{ inputs.SCAN_TYPE == 'image' && '' || inputs.SCAN_REF }}
+        format: json
+        output: ${{ steps.defaults.outputs.json_file }}
+        severity: ${{ inputs.SEVERITY }}
+        scanners: ${{ steps.defaults.outputs.scanners }}
+        exit-code: '0'
+        ignore-unfixed: ${{ inputs.IGNORE_UNFIXED }}
+        trivyignores: ${{ inputs.TRIVYIGNORES }}
+        cache: 'true'
+      env:
+        TRIVY_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        TRIVY_USERNAME: ${{ inputs.TRIVY_USERNAME }}
+        TRIVY_PASSWORD: ${{ inputs.TRIVY_PASSWORD }}
+
+    - name: Extract severity counts
+      if: always()
+      id: counts
+      env:
+        JSON_FILE: ${{ steps.defaults.outputs.json_file }}
+      shell: bash
+      run: |
+        if ! command -v jq > /dev/null 2>&1; then
+          sudo apt-get update -q && sudo apt-get install -y -q jq
+        fi
+        CRITICAL=0; HIGH=0; MEDIUM=0
+        if [ -f "$JSON_FILE" ]; then
+          # Vulnerabilities + misconfigurations + secrets all carry a Severity field
+          CRITICAL=$(jq '[.. | objects | select(has("Severity")) | select(.Severity=="CRITICAL")] | length' "$JSON_FILE" 2>/dev/null || echo 0)
+          HIGH=$(jq '[.. | objects | select(has("Severity")) | select(.Severity=="HIGH")] | length' "$JSON_FILE" 2>/dev/null || echo 0)
+          MEDIUM=$(jq '[.. | objects | select(has("Severity")) | select(.Severity=="MEDIUM")] | length' "$JSON_FILE" 2>/dev/null || echo 0)
+        fi
+        echo "critical=$CRITICAL" >> "$GITHUB_OUTPUT"
+        echo "high=$HIGH" >> "$GITHUB_OUTPUT"
+        echo "medium=$MEDIUM" >> "$GITHUB_OUTPUT"
+        echo "Findings: CRITICAL=$CRITICAL HIGH=$HIGH MEDIUM=$MEDIUM"
+
+    - name: Upload SARIF to Code Scanning
+      if: always() && inputs.UPLOAD_SARIF == 'true' && hashFiles(steps.defaults.outputs.sarif_file) != ''
+      uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
+      with:
+        sarif_file: ${{ steps.defaults.outputs.sarif_file }}
+        category: ${{ steps.defaults.outputs.sarif_category }}
+
+    - name: Upload SARIF as workflow artifact
+      if: always() && hashFiles(steps.defaults.outputs.sarif_file) != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: trivy-${{ inputs.SCAN_TYPE }}-${{ github.sha }}
+        path: ${{ steps.defaults.outputs.sarif_file }}
+        retention-days: 14
+
+    - name: Notify on Mattermost
+      if: always()
+      uses: imio/gha/mattermost-notify@v7
+      with:
+        MATTERMOST_WEBHOOK_URL: ${{ inputs.MATTERMOST_WEBHOOK_URL }}
+        STATUS: ${{ steps.scan.outcome == 'success' && 'success' || 'failure' }}
+        TITLE: "Trivy Scan (${{ inputs.SCAN_TYPE }})"
+        BODY: |
+          **Repository:** [${{ github.repository }}](${{ github.server_url }}/${{ github.repository }})
+          **Branch:** ${{ github.ref_name }}
+          **Commit:** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          **Target:** ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
+          **Findings:** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }}
+
+    - name: Re-raise scan failure
+      if: steps.scan.outcome == 'failure' && inputs.EXIT_CODE != '0'
+      shell: bash
+      run: |
+        echo "::error::Trivy scan reported findings at or above the configured severity (see Code Scanning tab)."
+        exit 1

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -130,7 +130,7 @@ runs:
         scan-ref: ${{ inputs.SCAN_TYPE == 'image' && '' || inputs.SCAN_REF }}
         format: json
         output: ${{ steps.defaults.outputs.json_file }}
-        severity: ${{ inputs.SEVERITY }}
+        severity: 'LOW,MEDIUM,HIGH,CRITICAL'
         scanners: ${{ steps.defaults.outputs.scanners }}
         exit-code: '0'
         ignore-unfixed: ${{ inputs.IGNORE_UNFIXED }}


### PR DESCRIPTION
Introduces two composite actions wrapping aquasecurity/trivy-action for security scanning :

- trivy-scan-notify: unified image / fs / config scan. Uploads SARIF to GitHub Code Scanning, archives it as a workflow artifact, and notifies Mattermost with parsed CRITICAL/HIGH/MEDIUM findings counts. Defaults pick per-SCAN_TYPE scanners (image=vuln,secret,misconfig ; fs=vuln,secret ; config=secret,misconfig). EXIT_CODE is exposed so callers can bootstrap with reporting-only before switching to blocking.
- trivy-sbom-notify: generates a CycloneDX/SPDX SBOM for a container image and uploads it as a workflow artifact (90-day retention by default).

External actions pinned by SHA:
  actions/checkout                  v6.0.2
  actions/upload-artifact           v7.0.1
  aquasecurity/trivy-action         v0.35.0 (built-in DB cache)
  github/codeql-action/upload-sarif v3.35.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two GitHub Actions: trivy-scan-notify (image/fs/config vulnerability & config scans with SARIF upload and severity counts) and trivy-sbom-notify (SBOM generation in CycloneDX/SPDX and artifact upload).
  * Optional Mattermost notifications with parsed CRITICAL/HIGH/MEDIUM counts and run metadata.

* **Documentation**
  * Updated changelog and README with usage, inputs, and examples for both actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->