### PR TITLE
Add/claude agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - `CLAUDE_SEVERITIES` input (default `CRITICAL,HIGH`) controls which severity levels are processed; append `,MEDIUM` to include medium findings
   - Advisories are deduplicated against existing drafts and processed in CRITICAL → HIGH → MEDIUM order
   - Requires `repository-advisories: write` permission in the calling workflow when `CLAUDE_ANALYSIS=true`
+  - Outputs `critical`, `high`, and `medium` (finding counts) are now exposed, enabling a two-job manual-approval pattern where job 1 scans and job 2 (gated by a GitHub Environment with required reviewers) runs Claude analysis without duplicating the prompt in caller repositories
 
 ## [v7.1.0] - 2026-04-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v7.2.0] - 2026-04-23
+### Added
+- claude-agent
+  - New composite action wrapping `anthropics/claude-code-action` (SHA-pinned) for running a Claude Code agent in CI pipelines
+  - Accepts a `prompt`, an optional newline-separated list of `files` to expose, a `model` override (default `claude-sonnet-4-6`), and an optional `GITHUB_TOKEN` for GitHub API operations (e.g. creating security advisories)
+  - Claude output is displayed in the GitHub Actions Step Summary
+### Changed
+- trivy-scan-notify
+  - New opt-in `CLAUDE_ANALYSIS` input: when `"true"`, invokes `claude-agent` after the scan to create private draft GitHub security advisories — one per finding
+  - `CLAUDE_SEVERITIES` input (default `CRITICAL,HIGH`) controls which severity levels are processed; append `,MEDIUM` to include medium findings
+  - Advisories are deduplicated against existing drafts and processed in CRITICAL → HIGH → MEDIUM order
+  - Requires `repository-advisories: write` permission in the calling workflow when `CLAUDE_ANALYSIS=true`
+
 ## [v7.1.0] - 2026-04-21
 ### Added
 - trivy-scan-notify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,19 @@
 ### Added
 - claude-agent
   - New composite action wrapping `anthropics/claude-code-action` (SHA-pinned) for running a Claude Code agent in CI pipelines
-  - Accepts a `prompt`, an optional newline-separated list of `files` to expose, a `model` override (default `claude-sonnet-4-6`), and an optional `GITHUB_TOKEN` for GitHub API operations (e.g. creating security advisories)
+  - Accepts a `PROMPT`, an optional newline-separated list of `FILES` to expose, a `MODEL` override (default `claude-sonnet-4-6`), and an optional `GITHUB_TOKEN` for GitHub API operations
   - Claude output is displayed in the GitHub Actions Step Summary
+- trivy-claude-analysis
+  - New composite action that reads a Trivy JSON report and asks Claude to create one private draft GitHub security advisory per finding
+  - Takes a `JSON_FILE` path (from `trivy-scan-notify`'s `json_file` output in the same job, or from `actions/download-artifact` in a later job)
+  - `SEVERITIES` input (default `CRITICAL,HIGH`) controls which severity levels are processed; append `,MEDIUM` to include medium findings
+  - Advisories are deduplicated against existing drafts and processed in CRITICAL → HIGH → MEDIUM order
+  - Requires `repository-advisories: write` permission in the calling workflow
+  - Enables a two-job manual-approval pattern: job 1 scans and uploads the JSON artifact, job 2 (gated by a GitHub Environment with required reviewers) downloads the exact artifact and runs Claude — no re-scan, no state drift, no `EXIT_CODE: '0'` hack
 ### Changed
 - trivy-scan-notify
-  - New opt-in `CLAUDE_ANALYSIS` input: when `"true"`, invokes `claude-agent` after the scan to create private draft GitHub security advisories — one per finding
-  - `CLAUDE_SEVERITIES` input (default `CRITICAL,HIGH`) controls which severity levels are processed; append `,MEDIUM` to include medium findings
-  - Advisories are deduplicated against existing drafts and processed in CRITICAL → HIGH → MEDIUM order
-  - Requires `repository-advisories: write` permission in the calling workflow when `CLAUDE_ANALYSIS=true`
-  - Outputs `critical`, `high`, and `medium` (finding counts) are now exposed, enabling a two-job manual-approval pattern where job 1 scans and job 2 (gated by a GitHub Environment with required reviewers) runs Claude analysis without duplicating the prompt in caller repositories
+  - Now uploads the Trivy JSON report as a workflow artifact (14-day retention) in addition to the SARIF artifact
+  - Exposes outputs `critical`, `high`, `medium`, `json_file`, and `artifact_name` for chaining with `trivy-claude-analysis`
 
 ## [v7.1.0] - 2026-04-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ This repository hosts a set of github actions we use to deploy our apps.
     - [trivy-sbom-notify](#trivy-sbom-notify)
       - [Inputs](#inputs-12)
       - [Example of usage](#example-of-usage-13)
-    - [claude-agent](#claude-agent)
+    - [trivy-claude-analysis](#trivy-claude-analysis)
       - [Inputs](#inputs-13)
       - [Example of usage](#example-of-usage-14)
+    - [claude-agent](#claude-agent)
+      - [Inputs](#inputs-14)
+      - [Example of usage](#example-of-usage-15)
   - [Contribute](#contribute)
     - [Release](#release)
 
@@ -357,8 +360,6 @@ External actions are pinned by SHA as required by the iMio security référentie
 
 > [!IMPORTANT]
 > The calling workflow must grant `permissions: security-events: write` for the SARIF upload to Code Scanning to succeed. On **private** repositories, GitHub Advanced Security must be enabled.
->
-> When `CLAUDE_ANALYSIS=true`, the workflow also needs `repository-advisories: write` to create private draft security advisories.
 
 #### Inputs
 
@@ -376,19 +377,18 @@ External actions are pinned by SHA as required by the iMio security référentie
 | SARIF_CATEGORY         |   no     | string  | `"trivy-<SCAN_TYPE>"`     | Code Scanning category for split results |
 | TRIVY_USERNAME         |   no     | string  |                           | Username for a private image registry |
 | TRIVY_PASSWORD         |   no     | string  |                           | Password for a private image registry |
-| GITHUB_TOKEN           |   no     | string  |                           | Pass `secrets.GITHUB_TOKEN` to avoid Trivy DB rate-limits and to allow Claude to create security advisories |
+| GITHUB_TOKEN           |   no     | string  |                           | Pass `secrets.GITHUB_TOKEN` to avoid Trivy DB rate-limits |
 | MATTERMOST_WEBHOOK_URL |   no     | string  |                           | Webhook URL to send notifications on Mattermost |
-| CLAUDE_ANALYSIS        |   no     | string  | `"false"`                 | Set to `"true"` to invoke Claude to analyze findings and create private draft security advisories (requires `ANTHROPIC_API_KEY`) |
-| ANTHROPIC_API_KEY      |   no     | string  |                           | Anthropic API key, required when `CLAUDE_ANALYSIS=true`. Pass `secrets.ANTHROPIC_API_KEY`. |
-| CLAUDE_SEVERITIES      |   no     | string  | `"CRITICAL,HIGH"`         | Comma-separated severities Claude should create advisories for. Append `,MEDIUM` to include medium findings. |
 
 #### Outputs
 
-| name     | description |
-| -------- | ----------- |
-| critical | Number of CRITICAL findings |
-| high     | Number of HIGH findings |
-| medium   | Number of MEDIUM findings |
+| name          | description |
+| ------------- | ----------- |
+| critical      | Number of CRITICAL findings |
+| high          | Number of HIGH findings |
+| medium        | Number of MEDIUM findings |
+| json_file     | Filename of the Trivy JSON report (relative to the workspace) — use as `JSON_FILE` input to `trivy-claude-analysis` in the same job |
+| artifact_name | Name of the uploaded Trivy JSON workflow artifact — use with `actions/download-artifact` in a later job |
 
 #### Example of usage
 
@@ -438,52 +438,7 @@ jobs:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
 ```
 
-#### Two-job pattern with manual approval
-
-Use this pattern to gate Claude analysis behind a human approval step. Job 1 scans and notifies; reviewers see the finding counts in Mattermost and approve job 2 only when Claude analysis is worth running. The prompt stays versioned inside the action — nothing is duplicated across repositories.
-
-> [!NOTE]
-> Create a `security-review` environment in repo Settings → Environments and add required reviewers before using this pattern.
-
-```yaml
-jobs:
-  scan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    outputs:
-      critical: ${{ steps.trivy.outputs.critical }}
-      high: ${{ steps.trivy.outputs.high }}
-    steps:
-      - uses: imio/gha/trivy-scan-notify@v7
-        id: trivy
-        with:
-          SCAN_TYPE: image
-          IMAGE_REF: registry.example.org/myapp:${{ github.sha }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-
-  claude-analysis:
-    needs: scan
-    if: needs.scan.outputs.critical > 0 || needs.scan.outputs.high > 0
-    environment: security-review   # pauses for human approval
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      repository-advisories: write
-    steps:
-      - uses: imio/gha/trivy-scan-notify@v7
-        with:
-          SCAN_TYPE: image
-          IMAGE_REF: registry.example.org/myapp:${{ github.sha }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CLAUDE_ANALYSIS: 'true'
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          EXIT_CODE: '0'         # findings already flagged in job 1
-          UPLOAD_SARIF: 'false'  # already uploaded in job 1
-```
+To run Claude on the scan results — either immediately in the same job, or after a manual approval step in a second job — see [`trivy-claude-analysis`](#trivy-claude-analysis) below.
 
 ---
 ### trivy-sbom-notify
@@ -518,6 +473,111 @@ jobs:
           IMAGE_REF: registry.example.org/${{ github.repository }}:${{ github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+```
+
+---
+### trivy-claude-analysis
+
+Post-processing action that reads a Trivy JSON report and asks Claude to create **private draft** GitHub repository security advisories — one per finding, at the severities you choose. The Trivy-specific prompt (CVE handling, ecosystem mapping, deduplication) is versioned inside this action, so caller repositories never duplicate it.
+
+> [!IMPORTANT]
+> The calling workflow must grant `permissions: repository-advisories: write` for advisory creation to succeed.
+
+This action is typically chained after [`trivy-scan-notify`](#trivy-scan-notify), which produces the JSON report and uploads it as a workflow artifact.
+
+#### Inputs
+
+| name              | required | type   | default               | description |
+| ----------------- | -------- | ------ | --------------------- | ----------- |
+| JSON_FILE         |   yes    | string |                       | Path to the Trivy JSON report (e.g. `trivy-image.json`). Use `steps.<id>.outputs.json_file` from `trivy-scan-notify` in the same job. |
+| SCAN_TYPE         |   yes    | string |                       | `image`, `fs`, or `config` |
+| TARGET            |   yes    | string |                       | What was scanned (image reference or scan path) |
+| SARIF_CATEGORY    |   no     | string | `"trivy-<SCAN_TYPE>"` | SARIF category from the originating scan, used to link advisories to the Code Scanning report |
+| SEVERITIES        |   no     | string | `"CRITICAL,HIGH"`     | Comma-separated severities. Append `,MEDIUM` to include medium findings. |
+| ANTHROPIC_API_KEY |   yes    | string |                       | Anthropic API key. Pass `secrets.ANTHROPIC_API_KEY`. |
+| GITHUB_TOKEN      |   yes    | string |                       | GitHub token with `repository-advisories: write`. Pass `secrets.GITHUB_TOKEN`. |
+| MODEL             |   no     | string | `"claude-sonnet-4-6"` | Claude model ID override |
+
+#### Example — single-job (scan and analyze immediately)
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+  repository-advisories: write
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: imio/gha/trivy-scan-notify@v7
+        id: trivy
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: registry.example.org/myapp:${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+
+      - uses: imio/gha/trivy-claude-analysis@v7
+        if: steps.trivy.outputs.critical > 0 || steps.trivy.outputs.high > 0
+        with:
+          JSON_FILE: ${{ steps.trivy.outputs.json_file }}
+          SCAN_TYPE: image
+          TARGET: registry.example.org/myapp:${{ github.sha }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The JSON file is already on disk from `trivy-scan-notify`, so no re-scan is needed.
+
+#### Example — two-job pattern with manual approval
+
+This pattern gates the Claude analysis (and the Anthropic token cost) behind a human approval step. Job 1 runs the scan and posts finding counts to Mattermost. A reviewer approves job 2 only when Claude analysis is worth running. Job 2 operates on the **exact JSON** produced by job 1 (downloaded from the workflow artifact), so there is no re-scan and no risk of state drift.
+
+> [!NOTE]
+> Create a `security-review` environment in repo Settings → Environments and add required reviewers before using this pattern.
+
+```yaml
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    outputs:
+      critical: ${{ steps.trivy.outputs.critical }}
+      high: ${{ steps.trivy.outputs.high }}
+      json_file: ${{ steps.trivy.outputs.json_file }}
+      artifact_name: ${{ steps.trivy.outputs.artifact_name }}
+    steps:
+      - uses: imio/gha/trivy-scan-notify@v7
+        id: trivy
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: registry.example.org/myapp:${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+
+  claude-analysis:
+    needs: scan
+    if: needs.scan.outputs.critical > 0 || needs.scan.outputs.high > 0
+    environment: security-review   # pauses for human approval
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      repository-advisories: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.scan.outputs.artifact_name }}
+
+      - uses: imio/gha/trivy-claude-analysis@v7
+        with:
+          JSON_FILE: ${{ needs.scan.outputs.json_file }}
+          SCAN_TYPE: image
+          TARGET: registry.example.org/myapp:${{ github.sha }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ---
@@ -562,25 +622,7 @@ jobs:
             requirements.txt
 ```
 
-Combined with `trivy-scan-notify` (opt-in via `CLAUDE_ANALYSIS`):
-
-```yaml
-permissions:
-  contents: read
-  security-events: write
-  repository-advisories: write
-
-steps:
-  - uses: imio/gha/trivy-scan-notify@v7
-    with:
-      SCAN_TYPE: image
-      IMAGE_REF: registry.example.org/myapp:${{ github.sha }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-      CLAUDE_ANALYSIS: 'true'
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      CLAUDE_SEVERITIES: 'CRITICAL,HIGH,MEDIUM'
-```
+For Trivy scan post-processing, use the dedicated [`trivy-claude-analysis`](#trivy-claude-analysis) action instead of calling `claude-agent` directly — it keeps the Trivy-specific prompt versioned inside the iMio actions.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -477,10 +477,10 @@ Run a [Claude Code](https://docs.anthropic.com/claude/claude-code) agent with a 
 
 | name              | required | type   | default               | description |
 | ----------------- | -------- | ------ | --------------------- | ----------- |
-| prompt            |   yes    | string |                       | Instructions for Claude |
-| files             |   no     | string |                       | Newline-separated list of file paths to expose to Claude (appended to the prompt as a "Files to examine" section) |
+| PROMPT            |   yes    | string |                       | Instructions for Claude |
+| FILES             |   no     | string |                       | Newline-separated list of file paths to expose to Claude (appended to the prompt as a "Files to examine" section) |
 | ANTHROPIC_API_KEY |   yes    | string |                       | Anthropic API key. Pass `secrets.ANTHROPIC_API_KEY`. |
-| model             |   no     | string | `"claude-sonnet-4-6"` | Claude model ID |
+| MODEL             |   no     | string | `"claude-sonnet-4-6"` | Claude model ID |
 | GITHUB_TOKEN      |   no     | string |                       | GitHub token forwarded to Claude for GitHub API operations (e.g. creating security advisories). Pass `secrets.GITHUB_TOKEN`. |
 
 Claude's output is displayed in the GitHub Actions Step Summary (`display_report: true`).
@@ -499,10 +499,10 @@ jobs:
         with:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          prompt: |
+          PROMPT: |
             Review the dependency list and create a private draft security advisory
             for any known critical vulnerability you find.
-          files: |
+          FILES: |
             package.json
             requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ This repository hosts a set of github actions we use to deploy our apps.
     - [trivy-sbom-notify](#trivy-sbom-notify)
       - [Inputs](#inputs-12)
       - [Example of usage](#example-of-usage-13)
+    - [claude-agent](#claude-agent)
+      - [Inputs](#inputs-13)
+      - [Example of usage](#example-of-usage-14)
   - [Contribute](#contribute)
     - [Release](#release)
 
@@ -354,6 +357,8 @@ External actions are pinned by SHA as required by the iMio security référentie
 
 > [!IMPORTANT]
 > The calling workflow must grant `permissions: security-events: write` for the SARIF upload to Code Scanning to succeed. On **private** repositories, GitHub Advanced Security must be enabled.
+>
+> When `CLAUDE_ANALYSIS=true`, the workflow also needs `repository-advisories: write` to create private draft security advisories.
 
 #### Inputs
 
@@ -371,8 +376,11 @@ External actions are pinned by SHA as required by the iMio security référentie
 | SARIF_CATEGORY         |   no     | string  | `"trivy-<SCAN_TYPE>"`     | Code Scanning category for split results |
 | TRIVY_USERNAME         |   no     | string  |                           | Username for a private image registry |
 | TRIVY_PASSWORD         |   no     | string  |                           | Password for a private image registry |
-| GITHUB_TOKEN           |   no     | string  |                           | Pass `secrets.GITHUB_TOKEN` to avoid Trivy DB rate-limits |
+| GITHUB_TOKEN           |   no     | string  |                           | Pass `secrets.GITHUB_TOKEN` to avoid Trivy DB rate-limits and to allow Claude to create security advisories |
 | MATTERMOST_WEBHOOK_URL |   no     | string  |                           | Webhook URL to send notifications on Mattermost |
+| CLAUDE_ANALYSIS        |   no     | string  | `"false"`                 | Set to `"true"` to invoke Claude to analyze findings and create private draft security advisories (requires `ANTHROPIC_API_KEY`) |
+| ANTHROPIC_API_KEY      |   no     | string  |                           | Anthropic API key, required when `CLAUDE_ANALYSIS=true`. Pass `secrets.ANTHROPIC_API_KEY`. |
+| CLAUDE_SEVERITIES      |   no     | string  | `"CRITICAL,HIGH"`         | Comma-separated severities Claude should create advisories for. Append `,MEDIUM` to include medium findings. |
 
 #### Example of usage
 
@@ -455,6 +463,68 @@ jobs:
           IMAGE_REF: registry.example.org/${{ github.repository }}:${{ github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+```
+
+---
+### claude-agent
+
+Run a [Claude Code](https://docs.anthropic.com/claude/claude-code) agent with a given prompt in a CI pipeline. Thin, opinionated wrapper around `anthropics/claude-code-action` with prompt composition, optional file exposure, model selection, and GitHub API access for operations such as creating security advisories.
+
+> [!NOTE]
+> The calling workflow must grant the permissions required for the operations Claude will perform. For security advisory creation, add `repository-advisories: write`.
+
+#### Inputs
+
+| name              | required | type   | default               | description |
+| ----------------- | -------- | ------ | --------------------- | ----------- |
+| prompt            |   yes    | string |                       | Instructions for Claude |
+| files             |   no     | string |                       | Newline-separated list of file paths to expose to Claude (appended to the prompt as a "Files to examine" section) |
+| ANTHROPIC_API_KEY |   yes    | string |                       | Anthropic API key. Pass `secrets.ANTHROPIC_API_KEY`. |
+| model             |   no     | string | `"claude-sonnet-4-6"` | Claude model ID |
+| GITHUB_TOKEN      |   no     | string |                       | GitHub token forwarded to Claude for GitHub API operations (e.g. creating security advisories). Pass `secrets.GITHUB_TOKEN`. |
+
+Claude's output is displayed in the GitHub Actions Step Summary (`display_report: true`).
+
+#### Example of usage
+
+```yaml
+jobs:
+  security-advisory:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      repository-advisories: write
+    steps:
+      - uses: imio/gha/claude-agent@v7
+        with:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Review the dependency list and create a private draft security advisory
+            for any known critical vulnerability you find.
+          files: |
+            package.json
+            requirements.txt
+```
+
+Combined with `trivy-scan-notify` (opt-in via `CLAUDE_ANALYSIS`):
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+  repository-advisories: write
+
+steps:
+  - uses: imio/gha/trivy-scan-notify@v7
+    with:
+      SCAN_TYPE: image
+      IMAGE_REF: registry.example.org/myapp:${{ github.sha }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+      CLAUDE_ANALYSIS: 'true'
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_SEVERITIES: 'CRITICAL,HIGH,MEDIUM'
 ```
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -382,6 +382,14 @@ External actions are pinned by SHA as required by the iMio security référentie
 | ANTHROPIC_API_KEY      |   no     | string  |                           | Anthropic API key, required when `CLAUDE_ANALYSIS=true`. Pass `secrets.ANTHROPIC_API_KEY`. |
 | CLAUDE_SEVERITIES      |   no     | string  | `"CRITICAL,HIGH"`         | Comma-separated severities Claude should create advisories for. Append `,MEDIUM` to include medium findings. |
 
+#### Outputs
+
+| name     | description |
+| -------- | ----------- |
+| critical | Number of CRITICAL findings |
+| high     | Number of HIGH findings |
+| medium   | Number of MEDIUM findings |
+
 #### Example of usage
 
 ```yaml
@@ -428,6 +436,53 @@ jobs:
           IMAGE_REF: ${{ github.repository }}:${{ github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+```
+
+#### Two-job pattern with manual approval
+
+Use this pattern to gate Claude analysis behind a human approval step. Job 1 scans and notifies; reviewers see the finding counts in Mattermost and approve job 2 only when Claude analysis is worth running. The prompt stays versioned inside the action — nothing is duplicated across repositories.
+
+> [!NOTE]
+> Create a `security-review` environment in repo Settings → Environments and add required reviewers before using this pattern.
+
+```yaml
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    outputs:
+      critical: ${{ steps.trivy.outputs.critical }}
+      high: ${{ steps.trivy.outputs.high }}
+    steps:
+      - uses: imio/gha/trivy-scan-notify@v7
+        id: trivy
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: registry.example.org/myapp:${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+
+  claude-analysis:
+    needs: scan
+    if: needs.scan.outputs.critical > 0 || needs.scan.outputs.high > 0
+    environment: security-review   # pauses for human approval
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      repository-advisories: write
+    steps:
+      - uses: imio/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: registry.example.org/myapp:${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_ANALYSIS: 'true'
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EXIT_CODE: '0'         # findings already flagged in job 1
+          UPLOAD_SARIF: 'false'  # already uploaded in job 1
 ```
 
 ---

--- a/claude-agent/action.yml
+++ b/claude-agent/action.yml
@@ -2,22 +2,22 @@ name: Claude agent
 description: Run a Claude Code agent with a given prompt, optionally focusing on specific files. Thin wrapper around anthropics/claude-code-action with sensible CI defaults.
 
 inputs:
-  prompt:
+  PROMPT:
     description: 'Instructions for Claude'
     required: true
-  files:
+  FILES:
     description: 'Newline-separated list of file paths to expose to Claude (appended to the prompt as context)'
     required: false
     default: ''
   ANTHROPIC_API_KEY:
     description: 'Anthropic API key (pass secrets.ANTHROPIC_API_KEY from the calling workflow)'
     required: true
-  model:
+  MODEL:
     description: 'Claude model ID'
     required: false
     default: 'claude-sonnet-4-6'
   GITHUB_TOKEN:
-    description: 'GitHub token forwarded to Claude for GitHub API operations (e.g. creating issues). Requires the appropriate permissions in the calling workflow (e.g. issues: write).'
+    description: 'GitHub token forwarded to Claude for GitHub API operations (e.g. creating security advisories). Requires the appropriate permissions in the calling workflow (e.g. repository-advisories: write).'
     required: false
     default: ''
 
@@ -28,8 +28,8 @@ runs:
       id: compose
       shell: bash
       env:
-        PROMPT: ${{ inputs.prompt }}
-        FILES: ${{ inputs.files }}
+        PROMPT: ${{ inputs.PROMPT }}
+        FILES: ${{ inputs.FILES }}
       run: |
         FULL_PROMPT="$PROMPT"
         if [ -n "$FILES" ]; then
@@ -49,5 +49,5 @@ runs:
         prompt: ${{ steps.compose.outputs.prompt }}
         anthropic_api_key: ${{ inputs.ANTHROPIC_API_KEY }}
         github_token: ${{ inputs.GITHUB_TOKEN }}
-        claude_args: '--model ${{ inputs.model }}'
+        claude_args: '--model ${{ inputs.MODEL }}'
         display_report: 'true'

--- a/claude-agent/action.yml
+++ b/claude-agent/action.yml
@@ -1,0 +1,53 @@
+name: Claude agent
+description: Run a Claude Code agent with a given prompt, optionally focusing on specific files. Thin wrapper around anthropics/claude-code-action with sensible CI defaults.
+
+inputs:
+  prompt:
+    description: 'Instructions for Claude'
+    required: true
+  files:
+    description: 'Newline-separated list of file paths to expose to Claude (appended to the prompt as context)'
+    required: false
+    default: ''
+  ANTHROPIC_API_KEY:
+    description: 'Anthropic API key (pass secrets.ANTHROPIC_API_KEY from the calling workflow)'
+    required: true
+  model:
+    description: 'Claude model ID'
+    required: false
+    default: 'claude-haiku-4-5-20251001'
+  GITHUB_TOKEN:
+    description: 'GitHub token forwarded to Claude for GitHub API operations (e.g. creating issues). Requires the appropriate permissions in the calling workflow (e.g. issues: write).'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Compose prompt
+      id: compose
+      shell: bash
+      env:
+        PROMPT: ${{ inputs.prompt }}
+        FILES: ${{ inputs.files }}
+      run: |
+        FULL_PROMPT="$PROMPT"
+        if [ -n "$FILES" ]; then
+          FILES_LIST=$(printf '%s' "$FILES" | sed '/^[[:space:]]*$/d' | sed 's/^/- /')
+          FULL_PROMPT="${FULL_PROMPT}"$'\n\n'"Files to examine:"$'\n'"${FILES_LIST}"
+        fi
+        DELIMITER="PROMPT_EOF_$(openssl rand -hex 8)"
+        {
+          echo "prompt<<$DELIMITER"
+          printf '%s\n' "$FULL_PROMPT"
+          echo "$DELIMITER"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Run Claude agent
+      uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb  # v1
+      with:
+        prompt: ${{ steps.compose.outputs.prompt }}
+        anthropic_api_key: ${{ inputs.ANTHROPIC_API_KEY }}
+        github_token: ${{ inputs.GITHUB_TOKEN }}
+        claude_args: '--model ${{ inputs.model }}'
+        display_report: 'true'

--- a/claude-agent/action.yml
+++ b/claude-agent/action.yml
@@ -15,7 +15,7 @@ inputs:
   model:
     description: 'Claude model ID'
     required: false
-    default: 'claude-haiku-4-5-20251001'
+    default: 'claude-sonnet-4-6'
   GITHUB_TOKEN:
     description: 'GitHub token forwarded to Claude for GitHub API operations (e.g. creating issues). Requires the appropriate permissions in the calling workflow (e.g. issues: write).'
     required: false

--- a/trivy-claude-analysis/action.yml
+++ b/trivy-claude-analysis/action.yml
@@ -42,6 +42,10 @@ runs:
           echo "::error::JSON_FILE '$JSON_FILE' does not exist. Ensure trivy-scan-notify ran in the same job, or the artifact was downloaded in this job."
           exit 1
         fi
+        if ! python3 -m json.tool "$JSON_FILE" > /dev/null 2>&1; then
+          echo "::error::JSON_FILE '$JSON_FILE' is not valid JSON. It may be empty, truncated, or corrupted — re-run trivy-scan-notify or re-download the artifact."
+          exit 1
+        fi
 
     - name: Resolve SARIF category
       id: defaults

--- a/trivy-claude-analysis/action.yml
+++ b/trivy-claude-analysis/action.yml
@@ -1,0 +1,124 @@
+name: Trivy Claude analysis
+description: Analyze a Trivy JSON scan report with Claude and create private draft GitHub security advisories — one per finding.
+
+inputs:
+  JSON_FILE:
+    description: 'Path to the Trivy JSON report produced by trivy-scan-notify (e.g. trivy-image.json)'
+    required: true
+  SCAN_TYPE:
+    description: 'Trivy scan type (image, fs, config) — used for prompt context and advisory titling'
+    required: true
+  TARGET:
+    description: 'What was scanned (image reference or scan path) — used for prompt context'
+    required: true
+  SARIF_CATEGORY:
+    description: 'SARIF category from the originating scan — used to link advisories to the Code Scanning report (defaults to trivy-<SCAN_TYPE>)'
+    required: false
+    default: ''
+  SEVERITIES:
+    description: 'Comma-separated severities Claude should create security advisories for (CRITICAL, HIGH, MEDIUM).'
+    required: false
+    default: 'CRITICAL,HIGH'
+  ANTHROPIC_API_KEY:
+    description: 'Anthropic API key. Pass secrets.ANTHROPIC_API_KEY from the calling workflow.'
+    required: true
+  GITHUB_TOKEN:
+    description: 'GitHub token with repository-advisories: write. Pass secrets.GITHUB_TOKEN from the calling workflow.'
+    required: true
+  MODEL:
+    description: 'Claude model ID override'
+    required: false
+    default: 'claude-sonnet-4-6'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        JSON_FILE: ${{ inputs.JSON_FILE }}
+      run: |
+        if [ ! -f "$JSON_FILE" ]; then
+          echo "::error::JSON_FILE '$JSON_FILE' does not exist. Ensure trivy-scan-notify ran in the same job, or the artifact was downloaded in this job."
+          exit 1
+        fi
+
+    - name: Resolve SARIF category
+      id: defaults
+      shell: bash
+      env:
+        SARIF_CATEGORY_IN: ${{ inputs.SARIF_CATEGORY }}
+        SCAN_TYPE: ${{ inputs.SCAN_TYPE }}
+      run: |
+        if [ -n "$SARIF_CATEGORY_IN" ]; then
+          CATEGORY="$SARIF_CATEGORY_IN"
+        else
+          CATEGORY="trivy-$SCAN_TYPE"
+        fi
+        echo "sarif_category=$CATEGORY" >> "$GITHUB_OUTPUT"
+
+    - name: Run Claude advisory analysis
+      uses: imio/gha/claude-agent@v7
+      with:
+        ANTHROPIC_API_KEY: ${{ inputs.ANTHROPIC_API_KEY }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        MODEL: ${{ inputs.MODEL }}
+        FILES: ${{ inputs.JSON_FILE }}
+        PROMPT: |
+          You are analyzing a Trivy security scan report and creating private draft GitHub repository security advisories — one advisory per finding. Do not publish any advisory.
+
+          ## Scan context
+          - Type: ${{ inputs.SCAN_TYPE }}
+          - Target: ${{ inputs.TARGET }}
+          - Commit: ${{ github.sha }} (branch: ${{ github.ref_name }})
+          - Severities to process: ${{ inputs.SEVERITIES }}
+          - Code Scanning report: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
+
+          ## Trivy JSON structure
+          The report has `Results[].Vulnerabilities[]` (CVEs, each with `VulnerabilityID`, `PkgName`, `InstalledVersion`, `FixedVersion`, `Severity`, `CVSS.nvd.V3Score`) and `Results[].Misconfigurations[]` (each with `ID`, `Title`, `Severity`). `Results[].Type` indicates the package ecosystem (e.g. `debian`, `npm`, `pip`, `gem`).
+
+          ## How to create a security advisory
+          Build the `vulnerabilities` array entry, then POST:
+          ```bash
+          gh api --method POST "/repos/$GITHUB_REPOSITORY/security-advisories" \
+            --field summary="<title>" \
+            --field description="<markdown body>" \
+            --field severity="<critical|high|medium>" \
+            --field 'vulnerabilities=[{"package":{"ecosystem":"<ecosystem>","name":"<PkgName>"},"vulnerable_version_range":"= <InstalledVersion>"}]'
+          ```
+          Add `"patched_versions":"<FixedVersion>"` to the vulnerability object **only** when `FixedVersion` is non-empty and non-null; omit the field entirely otherwise.
+
+          Derive `ecosystem` from `Results[].Type` using this mapping (GitHub advisory API values):
+          | Results[].Type | ecosystem to use |
+          |----------------|-----------------|
+          | npm            | npm             |
+          | pip            | pip             |
+          | go             | go              |
+          | maven          | maven           |
+          | nuget          | nuget           |
+          | pub            | pub             |
+          | erlang         | erlang          |
+          | gem            | rubygems        |
+          | rust-crate     | rust            |
+          | anything else (debian, alpine, ubuntu, rpm, etc.) | other |
+
+          ## Step 1 — Deduplicate
+          Run `gh api "/repos/$GITHUB_REPOSITORY/security-advisories?state=draft&per_page=100" --jq '.[].summary'` and collect existing summaries. For each finding, skip creating an advisory if an existing draft already contains the CVE ID or vulnerability name in its summary.
+
+          ## Step 2 — Create one advisory per finding
+          Process only the severities listed in "Severities to process" above (case-insensitive). For each matching finding in the JSON, create one advisory with:
+          - **summary**: `<SEVERITY>: <VulnerabilityID-or-Title> in <PkgName>@<InstalledVersion>`
+          - **severity**: severity in lowercase (`critical`, `high`, or `medium`)
+          - **description** (markdown):
+            * **CVE / ID**: link to https://nvd.nist.gov/vuln/detail/<CVE> if a CVE ID is present
+            * **CVSS v3 score**: include if present in the JSON
+            * **Affected**: `<PkgName> <InstalledVersion>` → fix: `<FixedVersion>` (or "no fix available")
+            * **What it is**: concise technical description of the flaw class (RCE, SSRF, auth bypass, etc.)
+            * **Project impact**: state what you can infer from the component's role; explicitly note that code-path reachability cannot be determined without manual review
+            * **Exploitation conditions**: network access required? auth needed? special config? Rate the realistic risk as Low / Medium / High given the likely deployment context
+            * **Remediation**: upgrade command or config change
+            * **Detected in**: `${{ github.sha }}` (`${{ github.ref_name }}`)
+            * **Code Scanning**: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
+
+          Process findings in severity order: CRITICAL first, then HIGH, then MEDIUM.
+          At the end, print a summary: how many advisories were created, skipped (duplicate), and skipped (severity not in scope).

--- a/trivy-claude-analysis/action.yml
+++ b/trivy-claude-analysis/action.yml
@@ -78,8 +78,10 @@ runs:
           - Severities to process: ${{ inputs.SEVERITIES }}
           - Code Scanning report: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
 
-          ## Trivy JSON structure
-          The report has `Results[].Vulnerabilities[]` (CVEs, each with `VulnerabilityID`, `PkgName`, `InstalledVersion`, `FixedVersion`, `Severity`, `CVSS.nvd.V3Score`) and `Results[].Misconfigurations[]` (each with `ID`, `Title`, `Severity`). `Results[].Type` indicates the package ecosystem (e.g. `debian`, `npm`, `pip`, `gem`).
+          ## Trivy JSON structure — scope
+          Process **only** `Results[].Vulnerabilities[]` entries (CVEs), each with `VulnerabilityID`, `PkgName`, `InstalledVersion`, `FixedVersion`, `Severity`, `CVSS.nvd.V3Score`. `Results[].Type` indicates the package ecosystem (e.g. `debian`, `npm`, `pip`, `gem`).
+
+          **Ignore** `Results[].Misconfigurations[]`, `Results[].Secrets[]`, and any other non-CVE finding types. They do not have a package associated with them and do not fit the GitHub Security Advisory model, which requires an ecosystem + package name. These findings are already surfaced through the SARIF upload to Code Scanning (see the "Code Scanning report" link in the Scan context).
 
           ## How to create a security advisory
           Build the `vulnerabilities` array entry, then POST:
@@ -110,8 +112,8 @@ runs:
           Run `gh api "/repos/$GITHUB_REPOSITORY/security-advisories?state=draft&per_page=100" --jq '.[].summary'` and collect existing summaries. For each finding, skip creating an advisory if an existing draft already contains the CVE ID or vulnerability name in its summary.
 
           ## Step 2 — Create one advisory per finding
-          Process only the severities listed in "Severities to process" above (case-insensitive). For each matching finding in the JSON, create one advisory with:
-          - **summary**: `<SEVERITY>: <VulnerabilityID-or-Title> in <PkgName>@<InstalledVersion>`
+          Iterate over `Results[].Vulnerabilities[]` only (ignore other finding types per the scope rule above). Process only entries whose `Severity` is in the "Severities to process" list (case-insensitive). For each matching vulnerability, create one advisory with:
+          - **summary**: `<SEVERITY>: <VulnerabilityID> in <PkgName>@<InstalledVersion>`
           - **severity**: severity in lowercase (`critical`, `high`, or `medium`)
           - **description** (markdown):
             * **CVE / ID**: link to https://nvd.nist.gov/vuln/detail/<CVE> if a CVE ID is present
@@ -124,5 +126,5 @@ runs:
             * **Detected in**: `${{ github.sha }}` (`${{ github.ref_name }}`)
             * **Code Scanning**: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
 
-          Process findings in severity order: CRITICAL first, then HIGH, then MEDIUM.
-          At the end, print a summary: how many advisories were created, skipped (duplicate), and skipped (severity not in scope).
+          Process vulnerabilities in severity order: CRITICAL first, then HIGH, then MEDIUM.
+          At the end, print a summary: how many advisories were created, skipped (duplicate), skipped (severity not in scope), and the count of non-vulnerability findings (misconfigurations, secrets, etc.) that were ignored — refer reviewers to the Code Scanning report link for those.

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -68,6 +68,16 @@ inputs:
     description: 'Comma-separated severities Claude should create security advisories for (CRITICAL, HIGH, MEDIUM). Only takes effect when CLAUDE_ANALYSIS=true.'
     required: false
     default: 'CRITICAL,HIGH'
+outputs:
+  critical:
+    description: 'Number of CRITICAL findings'
+    value: ${{ steps.counts.outputs.critical }}
+  high:
+    description: 'Number of HIGH findings'
+    value: ${{ steps.counts.outputs.high }}
+  medium:
+    description: 'Number of MEDIUM findings'
+    value: ${{ steps.counts.outputs.medium }}
 runs:
   using: 'composite'
   steps:

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -238,15 +238,29 @@ runs:
           The report has `Results[].Vulnerabilities[]` (CVEs, each with `VulnerabilityID`, `PkgName`, `InstalledVersion`, `FixedVersion`, `Severity`, `CVSS.nvd.V3Score`) and `Results[].Misconfigurations[]` (each with `ID`, `Title`, `Severity`). `Results[].Type` indicates the package ecosystem (e.g. `debian`, `npm`, `pip`, `gem`).
 
           ## How to create a security advisory
+          Build the `vulnerabilities` array entry, then POST:
           ```bash
           gh api --method POST "/repos/$GITHUB_REPOSITORY/security-advisories" \
             --field summary="<title>" \
             --field description="<markdown body>" \
             --field severity="<critical|high|medium>" \
-            --field 'vulnerabilities=[{"package":{"ecosystem":"<type-or-other>","name":"<PkgName>"},"vulnerable_version_range":"= <InstalledVersion>","patched_versions":"<FixedVersion>"}]'
+            --field 'vulnerabilities=[{"package":{"ecosystem":"<ecosystem>","name":"<PkgName>"},"vulnerable_version_range":"= <InstalledVersion>"}]'
           ```
-          Use `ecosystem` from `Results[].Type` when it matches a known value (npm, pip, gem, go, maven, nuget, rust-crate, erlang, pub); otherwise use `other`.
-          Omit `patched_versions` from the payload if `FixedVersion` is empty.
+          Add `"patched_versions":"<FixedVersion>"` to the vulnerability object **only** when `FixedVersion` is non-empty and non-null; omit the field entirely otherwise.
+
+          Derive `ecosystem` from `Results[].Type` using this mapping (GitHub advisory API values):
+          | Results[].Type | ecosystem to use |
+          |----------------|-----------------|
+          | npm            | npm             |
+          | pip            | pip             |
+          | go             | go              |
+          | maven          | maven           |
+          | nuget          | nuget           |
+          | pub            | pub             |
+          | erlang         | erlang          |
+          | gem            | rubygems        |
+          | rust-crate     | rust            |
+          | anything else (debian, alpine, ubuntu, rpm, etc.) | other |
 
           ## Step 1 — Deduplicate
           Run `gh api "/repos/$GITHUB_REPOSITORY/security-advisories?state=draft&per_page=100" --jq '.[].summary'` and collect existing summaries. For each finding, skip creating an advisory if an existing draft already contains the CVE ID or vulnerability name in its summary.

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -56,18 +56,6 @@ inputs:
     description: 'Webhook URL for Mattermost notification. If empty, notification is skipped.'
     required: false
     default: ''
-  CLAUDE_ANALYSIS:
-    description: 'Set to "true" to invoke Claude to create private draft security advisories for findings at the severities defined by CLAUDE_SEVERITIES (requires ANTHROPIC_API_KEY and GITHUB_TOKEN)'
-    required: false
-    default: 'false'
-  ANTHROPIC_API_KEY:
-    description: 'Anthropic API key, required when CLAUDE_ANALYSIS=true (pass secrets.ANTHROPIC_API_KEY)'
-    required: false
-    default: ''
-  CLAUDE_SEVERITIES:
-    description: 'Comma-separated severities Claude should create security advisories for (CRITICAL, HIGH, MEDIUM). Only takes effect when CLAUDE_ANALYSIS=true.'
-    required: false
-    default: 'CRITICAL,HIGH'
 outputs:
   critical:
     description: 'Number of CRITICAL findings'
@@ -78,6 +66,12 @@ outputs:
   medium:
     description: 'Number of MEDIUM findings'
     value: ${{ steps.counts.outputs.medium }}
+  json_file:
+    description: 'Filename of the Trivy JSON report (relative to the workspace), for use with trivy-claude-analysis in the same job'
+    value: ${{ steps.defaults.outputs.json_file }}
+  artifact_name:
+    description: 'Name of the uploaded Trivy JSON workflow artifact, for use with actions/download-artifact in a later job'
+    value: trivy-${{ inputs.SCAN_TYPE }}-json-${{ github.sha }}
 runs:
   using: 'composite'
   steps:
@@ -200,6 +194,14 @@ runs:
         path: ${{ steps.defaults.outputs.sarif_file }}
         retention-days: 14
 
+    - name: Upload Trivy JSON as workflow artifact
+      if: always() && hashFiles(steps.defaults.outputs.json_file) != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: trivy-${{ inputs.SCAN_TYPE }}-json-${{ github.sha }}
+        path: ${{ steps.defaults.outputs.json_file }}
+        retention-days: 14
+
     - name: Notify on Mattermost
       if: always()
       uses: imio/gha/mattermost-notify@v7
@@ -213,85 +215,6 @@ runs:
           **Commit:** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
           **Target:** ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
           **Findings:** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }}
-
-    - name: Validate Claude analysis inputs
-      if: always() && inputs.CLAUDE_ANALYSIS == 'true' && steps.defaults.outcome == 'success' && hashFiles(steps.defaults.outputs.json_file) != ''
-      shell: bash
-      run: |
-        if [ -z "${{ inputs.ANTHROPIC_API_KEY }}" ]; then
-          echo "::error::CLAUDE_ANALYSIS=true but ANTHROPIC_API_KEY is empty. Pass secrets.ANTHROPIC_API_KEY to this action."
-          exit 1
-        fi
-        if [ -z "${{ inputs.GITHUB_TOKEN }}" ]; then
-          echo "::error::CLAUDE_ANALYSIS=true but GITHUB_TOKEN is empty. Pass secrets.GITHUB_TOKEN and grant repository-advisories: write in the calling workflow."
-          exit 1
-        fi
-
-    - name: Claude analysis of findings
-      if: always() && inputs.CLAUDE_ANALYSIS == 'true' && steps.defaults.outcome == 'success' && hashFiles(steps.defaults.outputs.json_file) != ''
-      uses: imio/gha/claude-agent@v7
-      with:
-        ANTHROPIC_API_KEY: ${{ inputs.ANTHROPIC_API_KEY }}
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        FILES: ${{ steps.defaults.outputs.json_file }}
-        PROMPT: |
-          You are analyzing a Trivy security scan report and creating private draft GitHub repository security advisories — one advisory per finding. Do not publish any advisory.
-
-          ## Scan context
-          - Type: ${{ inputs.SCAN_TYPE }}
-          - Target: ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
-          - Commit: ${{ github.sha }} (branch: ${{ github.ref_name }})
-          - Severities to process: ${{ inputs.CLAUDE_SEVERITIES }}
-          - Code Scanning report: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
-
-          ## Trivy JSON structure
-          The report has `Results[].Vulnerabilities[]` (CVEs, each with `VulnerabilityID`, `PkgName`, `InstalledVersion`, `FixedVersion`, `Severity`, `CVSS.nvd.V3Score`) and `Results[].Misconfigurations[]` (each with `ID`, `Title`, `Severity`). `Results[].Type` indicates the package ecosystem (e.g. `debian`, `npm`, `pip`, `gem`).
-
-          ## How to create a security advisory
-          Build the `vulnerabilities` array entry, then POST:
-          ```bash
-          gh api --method POST "/repos/$GITHUB_REPOSITORY/security-advisories" \
-            --field summary="<title>" \
-            --field description="<markdown body>" \
-            --field severity="<critical|high|medium>" \
-            --field 'vulnerabilities=[{"package":{"ecosystem":"<ecosystem>","name":"<PkgName>"},"vulnerable_version_range":"= <InstalledVersion>"}]'
-          ```
-          Add `"patched_versions":"<FixedVersion>"` to the vulnerability object **only** when `FixedVersion` is non-empty and non-null; omit the field entirely otherwise.
-
-          Derive `ecosystem` from `Results[].Type` using this mapping (GitHub advisory API values):
-          | Results[].Type | ecosystem to use |
-          |----------------|-----------------|
-          | npm            | npm             |
-          | pip            | pip             |
-          | go             | go              |
-          | maven          | maven           |
-          | nuget          | nuget           |
-          | pub            | pub             |
-          | erlang         | erlang          |
-          | gem            | rubygems        |
-          | rust-crate     | rust            |
-          | anything else (debian, alpine, ubuntu, rpm, etc.) | other |
-
-          ## Step 1 — Deduplicate
-          Run `gh api "/repos/$GITHUB_REPOSITORY/security-advisories?state=draft&per_page=100" --jq '.[].summary'` and collect existing summaries. For each finding, skip creating an advisory if an existing draft already contains the CVE ID or vulnerability name in its summary.
-
-          ## Step 2 — Create one advisory per finding
-          Process only the severities listed in "Severities to process" above (case-insensitive). For each matching finding in the JSON, create one advisory with:
-          - **summary**: `<SEVERITY>: <VulnerabilityID-or-Title> in <PkgName>@<InstalledVersion>`
-          - **severity**: severity in lowercase (`critical`, `high`, or `medium`)
-          - **description** (markdown):
-            * **CVE / ID**: link to https://nvd.nist.gov/vuln/detail/<CVE> if a CVE ID is present
-            * **CVSS v3 score**: include if present in the JSON
-            * **Affected**: `<PkgName> <InstalledVersion>` → fix: `<FixedVersion>` (or "no fix available")
-            * **What it is**: concise technical description of the flaw class (RCE, SSRF, auth bypass, etc.)
-            * **Project impact**: state what you can infer from the component's role; explicitly note that code-path reachability cannot be determined without manual review
-            * **Exploitation conditions**: network access required? auth needed? special config? Rate the realistic risk as Low / Medium / High given the likely deployment context
-            * **Remediation**: upgrade command or config change
-            * **Detected in**: `${{ github.sha }}` (`${{ github.ref_name }}`)
-            * **Code Scanning**: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
-
-          Process findings in severity order: CRITICAL first, then HIGH, then MEDIUM.
-          At the end, print a summary: how many advisories were created, skipped (duplicate), and skipped (severity not in scope).
 
     - name: Re-raise scan failure
       if: steps.scan.outcome == 'failure' && inputs.EXIT_CODE != '0'

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -57,7 +57,7 @@ inputs:
     required: false
     default: ''
   CLAUDE_ANALYSIS:
-    description: 'Set to "true" to invoke Claude to analyze CRITICAL and HIGH findings and propose fixes (requires ANTHROPIC_API_KEY)'
+    description: 'Set to "true" to invoke Claude to create private draft security advisories for findings at the severities defined by CLAUDE_SEVERITIES (requires ANTHROPIC_API_KEY and GITHUB_TOKEN)'
     required: false
     default: 'false'
   ANTHROPIC_API_KEY:

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -64,14 +64,10 @@ inputs:
     description: 'Anthropic API key, required when CLAUDE_ANALYSIS=true (pass secrets.ANTHROPIC_API_KEY)'
     required: false
     default: ''
-  CLAUDE_MAX_ADVISORIES:
-    description: 'Maximum number of individual security advisories to create for CRITICAL findings. If the count exceeds this, a single summary advisory is created instead. Set to 0 to always use a summary.'
+  CLAUDE_SEVERITIES:
+    description: 'Comma-separated severities Claude should create security advisories for (CRITICAL, HIGH, MEDIUM). Only takes effect when CLAUDE_ANALYSIS=true.'
     required: false
-    default: '10'
-  CLAUDE_ANALYZE_MEDIUM:
-    description: 'Set to "true" to also create a summary security advisory for MEDIUM findings (requires CLAUDE_ANALYSIS=true)'
-    required: false
-    default: 'false'
+    default: 'CRITICAL,HIGH'
 runs:
   using: 'composite'
   steps:
@@ -216,37 +212,36 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         files: ${{ steps.defaults.outputs.json_file }}
         prompt: |
-          You are analyzing a Trivy security scan report and creating private GitHub repository security advisories for actionable findings.
-          Advisories are draft and private by default — do not publish them.
+          You are analyzing a Trivy security scan report and creating private draft GitHub repository security advisories — one advisory per finding. Do not publish any advisory.
 
           ## Scan context
           - Type: ${{ inputs.SCAN_TYPE }}
           - Target: ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
           - Commit: ${{ github.sha }} (branch: ${{ github.ref_name }})
+          - Severities to process: ${{ inputs.CLAUDE_SEVERITIES }}
           - Code Scanning report: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
 
           ## Trivy JSON structure
           The report has `Results[].Vulnerabilities[]` (CVEs, each with `VulnerabilityID`, `PkgName`, `InstalledVersion`, `FixedVersion`, `Severity`, `CVSS.nvd.V3Score`) and `Results[].Misconfigurations[]` (each with `ID`, `Title`, `Severity`). `Results[].Type` indicates the package ecosystem (e.g. `debian`, `npm`, `pip`, `gem`).
 
           ## How to create a security advisory
-          Use the GitHub API. For each advisory, build a JSON payload and post it:
           ```bash
           gh api --method POST "/repos/$GITHUB_REPOSITORY/security-advisories" \
             --field summary="<title>" \
             --field description="<markdown body>" \
             --field severity="<critical|high|medium>" \
-            --field 'vulnerabilities=[{"package":{"ecosystem":"<type-or-other>","name":"<PkgName>"},"vulnerable_version_range":"= <InstalledVersion>","patched_versions":"<FixedVersion or null>"}]'
+            --field 'vulnerabilities=[{"package":{"ecosystem":"<type-or-other>","name":"<PkgName>"},"vulnerable_version_range":"= <InstalledVersion>","patched_versions":"<FixedVersion>"}]'
           ```
           Use `ecosystem` from `Results[].Type` when it matches a known value (npm, pip, gem, go, maven, nuget, rust-crate, erlang, pub); otherwise use `other`.
-          If `FixedVersion` is empty, omit `patched_versions` from the payload.
+          Omit `patched_versions` from the payload if `FixedVersion` is empty.
 
           ## Step 1 — Deduplicate
-          Run `gh api "/repos/$GITHUB_REPOSITORY/security-advisories?state=draft&per_page=100" --jq '.[].summary'` and collect existing summaries. Skip creating an advisory if an existing one already contains the CVE ID or vulnerability name.
+          Run `gh api "/repos/$GITHUB_REPOSITORY/security-advisories?state=draft&per_page=100" --jq '.[].summary'` and collect existing summaries. For each finding, skip creating an advisory if an existing draft already contains the CVE ID or vulnerability name in its summary.
 
-          ## Step 2 — CRITICAL findings
-          Count all CRITICAL findings. If the count is within the cap (${{ inputs.CLAUDE_MAX_ADVISORIES }}), create one advisory per finding with:
-          - **summary**: `CRITICAL: <VulnerabilityID-or-Title> in <PkgName>@<InstalledVersion>`
-          - **severity**: `critical`
+          ## Step 2 — Create one advisory per finding
+          Process only the severities listed in "Severities to process" above (case-insensitive). For each matching finding in the JSON, create one advisory with:
+          - **summary**: `<SEVERITY>: <VulnerabilityID-or-Title> in <PkgName>@<InstalledVersion>`
+          - **severity**: severity in lowercase (`critical`, `high`, or `medium`)
           - **description** (markdown):
             * **CVE / ID**: link to https://nvd.nist.gov/vuln/detail/<CVE> if a CVE ID is present
             * **CVSS v3 score**: include if present in the JSON
@@ -258,20 +253,8 @@ runs:
             * **Detected in**: `${{ github.sha }}` (`${{ github.ref_name }}`)
             * **Code Scanning**: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
 
-          If the count exceeds the cap, create a single CRITICAL summary advisory instead (same body format as the HIGH summary below, summary field `CRITICAL findings summary — Trivy ${{ inputs.SCAN_TYPE }} scan`, severity `critical`).
-
-          ## Step 3 — HIGH findings
-          Create a single summary advisory (skip entirely if there are zero HIGH findings):
-          - **summary**: `HIGH findings summary — Trivy ${{ inputs.SCAN_TYPE }} scan`
-          - **severity**: `high`
-          - **description**: Markdown table `| Name | CVE | CVSS | Affected component & version | Fix version | Remediation |`, a short paragraph assessing overall HIGH risk exposure, a detected-in line (`${{ github.sha }}` / `${{ github.ref_name }}`), and the Code Scanning link.
-
-          ## Step 4 — MEDIUM findings (optional)
-          Only run this step if CLAUDE_ANALYZE_MEDIUM is true: ${{ inputs.CLAUDE_ANALYZE_MEDIUM }}
-          Create a single summary advisory (skip entirely if there are zero MEDIUM findings):
-          - **summary**: `MEDIUM findings summary — Trivy ${{ inputs.SCAN_TYPE }} scan`
-          - **severity**: `medium`
-          - **description**: Same table format as the HIGH summary above.
+          Process findings in severity order: CRITICAL first, then HIGH, then MEDIUM.
+          At the end, print a summary: how many advisories were created, skipped (duplicate), and skipped (severity not in scope).
 
     - name: Re-raise scan failure
       if: steps.scan.outcome == 'failure' && inputs.EXIT_CODE != '0'

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -205,7 +205,7 @@ runs:
           **Findings:** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }}
 
     - name: Validate Claude analysis inputs
-      if: always() && inputs.CLAUDE_ANALYSIS == 'true'
+      if: always() && inputs.CLAUDE_ANALYSIS == 'true' && steps.defaults.outcome == 'success' && hashFiles(steps.defaults.outputs.json_file) != ''
       shell: bash
       run: |
         if [ -z "${{ inputs.ANTHROPIC_API_KEY }}" ]; then
@@ -218,7 +218,7 @@ runs:
         fi
 
     - name: Claude analysis of findings
-      if: always() && inputs.CLAUDE_ANALYSIS == 'true'
+      if: always() && inputs.CLAUDE_ANALYSIS == 'true' && steps.defaults.outcome == 'success' && hashFiles(steps.defaults.outputs.json_file) != ''
       uses: imio/gha/claude-agent@v7
       with:
         ANTHROPIC_API_KEY: ${{ inputs.ANTHROPIC_API_KEY }}

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -56,6 +56,22 @@ inputs:
     description: 'Webhook URL for Mattermost notification. If empty, notification is skipped.'
     required: false
     default: ''
+  CLAUDE_ANALYSIS:
+    description: 'Set to "true" to invoke Claude to analyze CRITICAL and HIGH findings and propose fixes (requires ANTHROPIC_API_KEY)'
+    required: false
+    default: 'false'
+  ANTHROPIC_API_KEY:
+    description: 'Anthropic API key, required when CLAUDE_ANALYSIS=true (pass secrets.ANTHROPIC_API_KEY)'
+    required: false
+    default: ''
+  CLAUDE_MAX_ADVISORIES:
+    description: 'Maximum number of individual security advisories to create for CRITICAL findings. If the count exceeds this, a single summary advisory is created instead. Set to 0 to always use a summary.'
+    required: false
+    default: '10'
+  CLAUDE_ANALYZE_MEDIUM:
+    description: 'Set to "true" to also create a summary security advisory for MEDIUM findings (requires CLAUDE_ANALYSIS=true)'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -191,6 +207,71 @@ runs:
           **Commit:** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
           **Target:** ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
           **Findings:** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }}
+
+    - name: Claude analysis of findings
+      if: always() && inputs.CLAUDE_ANALYSIS == 'true'
+      uses: imio/gha/claude-agent@v7
+      with:
+        ANTHROPIC_API_KEY: ${{ inputs.ANTHROPIC_API_KEY }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        files: ${{ steps.defaults.outputs.json_file }}
+        prompt: |
+          You are analyzing a Trivy security scan report and creating private GitHub repository security advisories for actionable findings.
+          Advisories are draft and private by default — do not publish them.
+
+          ## Scan context
+          - Type: ${{ inputs.SCAN_TYPE }}
+          - Target: ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
+          - Commit: ${{ github.sha }} (branch: ${{ github.ref_name }})
+          - Code Scanning report: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
+
+          ## Trivy JSON structure
+          The report has `Results[].Vulnerabilities[]` (CVEs, each with `VulnerabilityID`, `PkgName`, `InstalledVersion`, `FixedVersion`, `Severity`, `CVSS.nvd.V3Score`) and `Results[].Misconfigurations[]` (each with `ID`, `Title`, `Severity`). `Results[].Type` indicates the package ecosystem (e.g. `debian`, `npm`, `pip`, `gem`).
+
+          ## How to create a security advisory
+          Use the GitHub API. For each advisory, build a JSON payload and post it:
+          ```bash
+          gh api --method POST "/repos/$GITHUB_REPOSITORY/security-advisories" \
+            --field summary="<title>" \
+            --field description="<markdown body>" \
+            --field severity="<critical|high|medium>" \
+            --field 'vulnerabilities=[{"package":{"ecosystem":"<type-or-other>","name":"<PkgName>"},"vulnerable_version_range":"= <InstalledVersion>","patched_versions":"<FixedVersion or null>"}]'
+          ```
+          Use `ecosystem` from `Results[].Type` when it matches a known value (npm, pip, gem, go, maven, nuget, rust-crate, erlang, pub); otherwise use `other`.
+          If `FixedVersion` is empty, omit `patched_versions` from the payload.
+
+          ## Step 1 — Deduplicate
+          Run `gh api "/repos/$GITHUB_REPOSITORY/security-advisories?state=draft&per_page=100" --jq '.[].summary'` and collect existing summaries. Skip creating an advisory if an existing one already contains the CVE ID or vulnerability name.
+
+          ## Step 2 — CRITICAL findings
+          Count all CRITICAL findings. If the count is within the cap (${{ inputs.CLAUDE_MAX_ADVISORIES }}), create one advisory per finding with:
+          - **summary**: `CRITICAL: <VulnerabilityID-or-Title> in <PkgName>@<InstalledVersion>`
+          - **severity**: `critical`
+          - **description** (markdown):
+            * **CVE / ID**: link to https://nvd.nist.gov/vuln/detail/<CVE> if a CVE ID is present
+            * **CVSS v3 score**: include if present in the JSON
+            * **Affected**: `<PkgName> <InstalledVersion>` → fix: `<FixedVersion>` (or "no fix available")
+            * **What it is**: concise technical description of the flaw class (RCE, SSRF, auth bypass, etc.)
+            * **Project impact**: state what you can infer from the component's role; explicitly note that code-path reachability cannot be determined without manual review
+            * **Exploitation conditions**: network access required? auth needed? special config? Rate the realistic risk as Low / Medium / High given the likely deployment context
+            * **Remediation**: upgrade command or config change
+            * **Detected in**: `${{ github.sha }}` (`${{ github.ref_name }}`)
+            * **Code Scanning**: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is:open+tool:${{ steps.defaults.outputs.sarif_category }}
+
+          If the count exceeds the cap, create a single CRITICAL summary advisory instead (same body format as the HIGH summary below, summary field `CRITICAL findings summary — Trivy ${{ inputs.SCAN_TYPE }} scan`, severity `critical`).
+
+          ## Step 3 — HIGH findings
+          Create a single summary advisory (skip entirely if there are zero HIGH findings):
+          - **summary**: `HIGH findings summary — Trivy ${{ inputs.SCAN_TYPE }} scan`
+          - **severity**: `high`
+          - **description**: Markdown table `| Name | CVE | CVSS | Affected component & version | Fix version | Remediation |`, a short paragraph assessing overall HIGH risk exposure, a detected-in line (`${{ github.sha }}` / `${{ github.ref_name }}`), and the Code Scanning link.
+
+          ## Step 4 — MEDIUM findings (optional)
+          Only run this step if CLAUDE_ANALYZE_MEDIUM is true: ${{ inputs.CLAUDE_ANALYZE_MEDIUM }}
+          Create a single summary advisory (skip entirely if there are zero MEDIUM findings):
+          - **summary**: `MEDIUM findings summary — Trivy ${{ inputs.SCAN_TYPE }} scan`
+          - **severity**: `medium`
+          - **description**: Same table format as the HIGH summary above.
 
     - name: Re-raise scan failure
       if: steps.scan.outcome == 'failure' && inputs.EXIT_CODE != '0'

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -204,6 +204,19 @@ runs:
           **Target:** ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
           **Findings:** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }}
 
+    - name: Validate Claude analysis inputs
+      if: always() && inputs.CLAUDE_ANALYSIS == 'true'
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.ANTHROPIC_API_KEY }}" ]; then
+          echo "::error::CLAUDE_ANALYSIS=true but ANTHROPIC_API_KEY is empty. Pass secrets.ANTHROPIC_API_KEY to this action."
+          exit 1
+        fi
+        if [ -z "${{ inputs.GITHUB_TOKEN }}" ]; then
+          echo "::error::CLAUDE_ANALYSIS=true but GITHUB_TOKEN is empty. Pass secrets.GITHUB_TOKEN and grant repository-advisories: write in the calling workflow."
+          exit 1
+        fi
+
     - name: Claude analysis of findings
       if: always() && inputs.CLAUDE_ANALYSIS == 'true'
       uses: imio/gha/claude-agent@v7

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -210,8 +210,8 @@ runs:
       with:
         ANTHROPIC_API_KEY: ${{ inputs.ANTHROPIC_API_KEY }}
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        files: ${{ steps.defaults.outputs.json_file }}
-        prompt: |
+        FILES: ${{ steps.defaults.outputs.json_file }}
+        PROMPT: |
           You are analyzing a Trivy security scan report and creating private draft GitHub repository security advisories — one advisory per finding. Do not publish any advisory.
 
           ## Scan context


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude agent action to run Claude-based analyses, emit AI output to workflow step summaries, accept optional files, and allow model override.
  * Added a Trivy→Claude analysis action that consumes a Trivy JSON report to create private draft security advisories per finding with severity filtering, deduplication, and a two-job manual-approval flow.

* **Improvements**
  * trivy-scan-notify now uploads the Trivy JSON report as a 14-day workflow artifact and exposes outputs for downstream chaining.

* **Documentation**
  * README expanded with usage, examples, and permissions guidance (advisory creation requires write permission and an Anthropic API key).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->