### PR TITLE
feat(trivy-scan-notify)!: introduce dual-parameter severity model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v8.0.0] - 2026-04-29
+### Changed
+- trivy-scan-notify
+  - **Breaking:** `SEVERITY` input renamed to `SEVERITIES` — update callers accordingly
+  - **Breaking:** `EXIT_CODE` input removed — replace with `FAIL_ON_SEVERITIES`
+  - New `FAIL_ON_SEVERITIES` input (default `""`) — comma-separated severities that trigger job failure; replaces `EXIT_CODE`. Leave empty to enable report-only mode (scan and notify without blocking the pipeline)
+  - Both scans (SARIF and JSON) now use `SEVERITIES` to filter findings; severity counts in the notification and outputs reflect only the selected levels
+  - New `low` output — number of LOW findings when `LOW` is included in `SEVERITIES`
+  - Notification body now labels findings with the active `SEVERITIES` value and includes the LOW count
+  - Notification STATUS reflects both infrastructure scan failures and `FAIL_ON_SEVERITIES` threshold breaches
+
 ## [v7.2.1] - 2026-04-23
 ### Fixed
 - trivy-claude-analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 ### Changed
 - trivy-scan-notify
   - **Breaking:** `SEVERITY` input renamed to `SEVERITIES` — update callers accordingly
+  - `SEVERITIES` default broadened to `CRITICAL,HIGH,MEDIUM,LOW` (was `HIGH,CRITICAL`) — scan output and notification counts now include MEDIUM and LOW out of the box; narrow it explicitly if you want quieter reports
   - **Breaking:** `EXIT_CODE` input removed — replace with `FAIL_ON_SEVERITIES`
-  - New `FAIL_ON_SEVERITIES` input (default `""`) — comma-separated severities that trigger job failure; replaces `EXIT_CODE`. Leave empty to enable report-only mode (scan and notify without blocking the pipeline)
+  - New `FAIL_ON_SEVERITIES` input (default `CRITICAL,HIGH`) — comma-separated severities that trigger job failure; replaces `EXIT_CODE`. Set to `""` to enable report-only mode (scan and notify without blocking the pipeline)
   - Both scans (SARIF and JSON) now use `SEVERITIES` to filter findings; severity counts in the notification and outputs reflect only the selected levels
   - New `low` output — number of LOW findings when `LOW` is included in `SEVERITIES`
   - Notification body now labels findings with the active `SEVERITIES` value and includes the LOW count
   - Notification STATUS reflects both infrastructure scan failures and `FAIL_ON_SEVERITIES` threshold breaches
+  - Action now validates that `FAIL_ON_SEVERITIES` is a subset of `SEVERITIES` and fails fast (exit 2) on contradictory configs — without this guard, a severity present in `FAIL_ON_SEVERITIES` but missing from `SEVERITIES` would be filtered out at scan time and silently ignored by the fail check
 
 ## [v7.2.1] - 2026-04-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   - Notification body now labels findings with the active `SEVERITIES` value and includes the LOW count
   - Notification STATUS reflects both infrastructure scan failures and `FAIL_ON_SEVERITIES` threshold breaches
   - Action now validates that `FAIL_ON_SEVERITIES` is a subset of `SEVERITIES` and fails fast (exit 2) on contradictory configs — without this guard, a severity present in `FAIL_ON_SEVERITIES` but missing from `SEVERITIES` would be filtered out at scan time and silently ignored by the fail check
+  - Action now validates that every severity in `SEVERITIES` and `FAIL_ON_SEVERITIES` is one of `UNKNOWN`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` and rejects empty `SEVERITIES` — typos no longer silently produce a green 0-finding job
+  - `UNKNOWN` is now a first-class severity: included in the whitelist, exposed via the new `unknown` output, counted in the notification, and accepted in `FAIL_ON_SEVERITIES`
+  - Severity counts and notification body are now dynamic — only the severities listed in `SEVERITIES` appear in the Mattermost `Findings:` line (e.g. `SEVERITIES=CRITICAL,HIGH` → `Findings: CRITICAL=2 HIGH=0`), matching the sister GitLab CI component (`devops/pipelines/security`)
 
 ## [v7.2.1] - 2026-04-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -368,9 +368,9 @@ External actions are pinned by SHA as required by the iMio security référentie
 | SCAN_TYPE              |   yes    | string  |                           | One of `image`, `fs`, `config` |
 | IMAGE_REF              |   cond.  | string  |                           | Image reference to scan (required when `SCAN_TYPE=image`) |
 | SCAN_REF               |   no     | string  | `"."`                     | Filesystem path (used when `SCAN_TYPE` is `fs` or `config`) |
-| SEVERITY               |   no     | string  | `"HIGH,CRITICAL"`         | Comma-separated severity levels to report |
+| SEVERITIES             |   no     | string  | `"HIGH,CRITICAL"`         | Comma-separated severity levels to include in all outputs (SARIF, notification, counts) |
+| FAIL_ON_SEVERITIES     |   no     | string  | `""`                      | Comma-separated severity levels that trigger job failure. Leave empty to enable **report-only mode** (never fail on findings). |
 | SCANNERS               |   no     | string  | *(per-type default)*      | Trivy scanners. If empty: `image`→`vuln,secret,misconfig`, `fs`→`vuln,secret`, `config`→`secret,misconfig` |
-| EXIT_CODE              |   no     | string  | `"1"`                     | Exit code when findings match `SEVERITY` (set to `"0"` during bootstrap) |
 | IGNORE_UNFIXED         |   no     | string  | `"true"`                  | Ignore vulnerabilities without a known fix |
 | TRIVYIGNORES           |   no     | string  | `".trivyignore"`          | Path to a `.trivyignore` file |
 | UPLOAD_SARIF           |   no     | string  | `"true"`                  | Upload SARIF to GitHub Code Scanning |
@@ -380,13 +380,16 @@ External actions are pinned by SHA as required by the iMio security référentie
 | GITHUB_TOKEN           |   no     | string  |                           | Pass `secrets.GITHUB_TOKEN` to avoid Trivy DB rate-limits |
 | MATTERMOST_WEBHOOK_URL |   no     | string  |                           | Webhook URL to send notifications on Mattermost |
 
+`SEVERITIES` and `FAIL_ON_SEVERITIES` are independent: you can report on `MEDIUM,HIGH,CRITICAL` while only failing on `HIGH,CRITICAL`, or set `FAIL_ON_SEVERITIES` to empty to scan and notify without ever blocking the pipeline.
+
 #### Outputs
 
 | name          | description |
 | ------------- | ----------- |
-| critical      | Number of CRITICAL findings |
-| high          | Number of HIGH findings |
-| medium        | Number of MEDIUM findings |
+| critical      | Number of CRITICAL findings (within `SEVERITIES`) |
+| high          | Number of HIGH findings (within `SEVERITIES`) |
+| medium        | Number of MEDIUM findings (within `SEVERITIES`) |
+| low           | Number of LOW findings (within `SEVERITIES`) |
 | json_file     | Filename of the Trivy JSON report (relative to the workspace) — use as `JSON_FILE` input to `trivy-claude-analysis` in the same job |
 | artifact_name | Name of the uploaded Trivy JSON workflow artifact — use with `actions/download-artifact` in a later job |
 
@@ -412,6 +415,8 @@ jobs:
         with:
           SCAN_TYPE: fs
           SCAN_REF: .
+          SEVERITIES: HIGH,CRITICAL
+          FAIL_ON_SEVERITIES: HIGH,CRITICAL
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
 
@@ -422,6 +427,8 @@ jobs:
         with:
           SCAN_TYPE: config
           SCAN_REF: .
+          SEVERITIES: MEDIUM,HIGH,CRITICAL   # report more, but only fail on HIGH+
+          FAIL_ON_SEVERITIES: HIGH,CRITICAL
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
 
@@ -434,6 +441,8 @@ jobs:
         with:
           SCAN_TYPE: image
           IMAGE_REF: ${{ github.repository }}:${{ github.sha }}
+          SEVERITIES: HIGH,CRITICAL
+          # FAIL_ON_SEVERITIES not set → report-only mode, pipeline never blocked
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
 ```

--- a/README.md
+++ b/README.md
@@ -368,8 +368,8 @@ External actions are pinned by SHA as required by the iMio security référentie
 | SCAN_TYPE              |   yes    | string  |                           | One of `image`, `fs`, `config` |
 | IMAGE_REF              |   cond.  | string  |                           | Image reference to scan (required when `SCAN_TYPE=image`) |
 | SCAN_REF               |   no     | string  | `"."`                     | Filesystem path (used when `SCAN_TYPE` is `fs` or `config`) |
-| SEVERITIES             |   no     | string  | `"HIGH,CRITICAL"`         | Comma-separated severity levels to include in all outputs (SARIF, notification, counts) |
-| FAIL_ON_SEVERITIES     |   no     | string  | `""`                      | Comma-separated severity levels that trigger job failure. Leave empty to enable **report-only mode** (never fail on findings). |
+| SEVERITIES             |   no     | string  | `"CRITICAL,HIGH,MEDIUM,LOW"` | Comma-separated severity levels to include in all outputs (SARIF, notification, counts) |
+| FAIL_ON_SEVERITIES     |   no     | string  | `"CRITICAL,HIGH"`         | Comma-separated severity levels that trigger job failure. Set to `""` to enable **report-only mode** (never fail on findings). |
 | SCANNERS               |   no     | string  | *(per-type default)*      | Trivy scanners. If empty: `image`→`vuln,secret,misconfig`, `fs`→`vuln,secret`, `config`→`secret,misconfig` |
 | IGNORE_UNFIXED         |   no     | string  | `"true"`                  | Ignore vulnerabilities without a known fix |
 | TRIVYIGNORES           |   no     | string  | `".trivyignore"`          | Path to a `.trivyignore` file |
@@ -380,7 +380,7 @@ External actions are pinned by SHA as required by the iMio security référentie
 | GITHUB_TOKEN           |   no     | string  |                           | Pass `secrets.GITHUB_TOKEN` to avoid Trivy DB rate-limits |
 | MATTERMOST_WEBHOOK_URL |   no     | string  |                           | Webhook URL to send notifications on Mattermost |
 
-`SEVERITIES` and `FAIL_ON_SEVERITIES` are independent: you can report on `MEDIUM,HIGH,CRITICAL` while only failing on `HIGH,CRITICAL`, or set `FAIL_ON_SEVERITIES` to empty to scan and notify without ever blocking the pipeline.
+`SEVERITIES` and `FAIL_ON_SEVERITIES` are independent: you can report on `MEDIUM,HIGH,CRITICAL` while only failing on `HIGH,CRITICAL`, or set `FAIL_ON_SEVERITIES` to empty to scan and notify without ever blocking the pipeline. `FAIL_ON_SEVERITIES` must be a subset of `SEVERITIES` — the action fails fast otherwise, since Trivy filters its output by `SEVERITIES` and any extra level would be silently dropped before the fail check.
 
 #### Outputs
 
@@ -442,7 +442,7 @@ jobs:
           SCAN_TYPE: image
           IMAGE_REF: ${{ github.repository }}:${{ github.sha }}
           SEVERITIES: HIGH,CRITICAL
-          # FAIL_ON_SEVERITIES not set → report-only mode, pipeline never blocked
+          FAIL_ON_SEVERITIES: ''   # report-only mode, pipeline never blocked
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
 ```

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ External actions are pinned by SHA as required by the iMio security référentie
 | SCAN_TYPE              |   yes    | string  |                           | One of `image`, `fs`, `config` |
 | IMAGE_REF              |   cond.  | string  |                           | Image reference to scan (required when `SCAN_TYPE=image`) |
 | SCAN_REF               |   no     | string  | `"."`                     | Filesystem path (used when `SCAN_TYPE` is `fs` or `config`) |
-| SEVERITIES             |   no     | string  | `"CRITICAL,HIGH,MEDIUM,LOW"` | Comma-separated severity levels to include in all outputs (SARIF, notification, counts) |
+| SEVERITIES             |   no     | string  | `"CRITICAL,HIGH,MEDIUM,LOW"` | Comma-separated severities reported in all outputs (SARIF, notification, counts). Allowed: `UNKNOWN`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`. Tokens are case-insensitive and whitespace-tolerant. |
 | FAIL_ON_SEVERITIES     |   no     | string  | `"CRITICAL,HIGH"`         | Comma-separated severity levels that trigger job failure. Set to `""` to enable **report-only mode** (never fail on findings). |
 | SCANNERS               |   no     | string  | *(per-type default)*      | Trivy scanners. If empty: `image`→`vuln,secret,misconfig`, `fs`→`vuln,secret`, `config`→`secret,misconfig` |
 | IGNORE_UNFIXED         |   no     | string  | `"true"`                  | Ignore vulnerabilities without a known fix |
@@ -380,7 +380,7 @@ External actions are pinned by SHA as required by the iMio security référentie
 | GITHUB_TOKEN           |   no     | string  |                           | Pass `secrets.GITHUB_TOKEN` to avoid Trivy DB rate-limits |
 | MATTERMOST_WEBHOOK_URL |   no     | string  |                           | Webhook URL to send notifications on Mattermost |
 
-`SEVERITIES` and `FAIL_ON_SEVERITIES` are independent: you can report on `MEDIUM,HIGH,CRITICAL` while only failing on `HIGH,CRITICAL`, or set `FAIL_ON_SEVERITIES` to empty to scan and notify without ever blocking the pipeline. `FAIL_ON_SEVERITIES` must be a subset of `SEVERITIES` — the action fails fast otherwise, since Trivy filters its output by `SEVERITIES` and any extra level would be silently dropped before the fail check.
+`SEVERITIES` and `FAIL_ON_SEVERITIES` are independent: you can report on `MEDIUM,HIGH,CRITICAL` while only failing on `HIGH,CRITICAL`, or set `FAIL_ON_SEVERITIES` to empty to scan and notify without ever blocking the pipeline. `FAIL_ON_SEVERITIES` must be a subset of `SEVERITIES` — the action fails fast otherwise, since Trivy filters its output by `SEVERITIES` and any extra level would be silently dropped before the fail check. The Mattermost notification's findings line lists exactly the severities included in `SEVERITIES`, in the order given — `SEVERITIES=CRITICAL,HIGH` produces `CRITICAL=N HIGH=N`, never `MEDIUM=0 LOW=0`.
 
 #### Outputs
 
@@ -390,6 +390,7 @@ External actions are pinned by SHA as required by the iMio security référentie
 | high          | Number of HIGH findings (within `SEVERITIES`) |
 | medium        | Number of MEDIUM findings (within `SEVERITIES`) |
 | low           | Number of LOW findings (within `SEVERITIES`) |
+| unknown       | Number of UNKNOWN findings (within `SEVERITIES`) |
 | json_file     | Filename of the Trivy JSON report (relative to the workspace) — use as `JSON_FILE` input to `trivy-claude-analysis` in the same job |
 | artifact_name | Name of the uploaded Trivy JSON workflow artifact — use with `actions/download-artifact` in a later job |
 
@@ -411,7 +412,7 @@ jobs:
   trivy-fs:
     runs-on: ubuntu-latest
     steps:
-      - uses: imio/gha/trivy-scan-notify@v7
+      - uses: imio/gha/trivy-scan-notify@v8
         with:
           SCAN_TYPE: fs
           SCAN_REF: .
@@ -423,7 +424,7 @@ jobs:
   trivy-iac:
     runs-on: ubuntu-latest
     steps:
-      - uses: imio/gha/trivy-scan-notify@v7
+      - uses: imio/gha/trivy-scan-notify@v8
         with:
           SCAN_TYPE: config
           SCAN_REF: .
@@ -437,7 +438,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - run: docker build -t ${{ github.repository }}:${{ github.sha }} .
-      - uses: imio/gha/trivy-scan-notify@v7
+      - uses: imio/gha/trivy-scan-notify@v8
         with:
           SCAN_TYPE: image
           IMAGE_REF: ${{ github.repository }}:${{ github.sha }}

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -88,6 +88,8 @@ runs:
         SCAN_TYPE: ${{ inputs.SCAN_TYPE }}
         SCANNERS_IN: ${{ inputs.SCANNERS }}
         SARIF_CATEGORY_IN: ${{ inputs.SARIF_CATEGORY }}
+        SEVERITIES_IN: ${{ inputs.SEVERITIES }}
+        FAIL_ON_SEVERITIES_IN: ${{ inputs.FAIL_ON_SEVERITIES }}
       shell: bash
       run: |
         if [ -n "$SCANNERS_IN" ]; then
@@ -106,6 +108,20 @@ runs:
         if [ "$SCAN_TYPE" = "image" ] && [ -z "${{ inputs.IMAGE_REF }}" ]; then
           echo "::error::IMAGE_REF is required when SCAN_TYPE=image"
           exit 2
+        fi
+        # Trivy filters scan output by SEVERITIES, so any severity in
+        # FAIL_ON_SEVERITIES that is not in SEVERITIES would be silently
+        # ignored by the fail-check step. Reject contradictory configs early.
+        if [ -n "$FAIL_ON_SEVERITIES_IN" ]; then
+          SEV_LIST=$(echo "$SEVERITIES_IN" | tr ',' '\n' | sed 's/[[:space:]]//g')
+          for sev in $(echo "$FAIL_ON_SEVERITIES_IN" | tr ',' ' '); do
+            sev_trim=$(echo "$sev" | tr -d '[:space:]')
+            [ -z "$sev_trim" ] && continue
+            if ! echo "$SEV_LIST" | grep -qxF "$sev_trim"; then
+              echo "::error::FAIL_ON_SEVERITIES contains '$sev_trim' which is not in SEVERITIES='$SEVERITIES_IN'. FAIL_ON_SEVERITIES must be a subset of SEVERITIES, otherwise findings at that severity are filtered out at scan time and silently ignored by the fail check."
+              exit 2
+            fi
+          done
         fi
         if [ -n "$SARIF_CATEGORY_IN" ]; then
           SARIF_CATEGORY_EFFECTIVE="$SARIF_CATEGORY_IN"
@@ -173,9 +189,13 @@ runs:
         fi
         CRITICAL=0; HIGH=0; MEDIUM=0; LOW=0
         if [ -f "$JSON_FILE" ]; then
+          # Normalize SEVERITIES once: split, strip whitespace, uppercase.
+          # Trivy's JSON .Severity is always uppercase, so $sev is passed
+          # to jq as-is (callers below use uppercase tokens).
+          SEV_NORM=$(echo "$SEVERITIES" | tr ',' '\n' | sed 's/[[:space:]]//g' | tr '[:lower:]' '[:upper:]')
           count_sev() {
             local sev="$1"
-            echo "$SEVERITIES" | tr ',' '\n' | grep -qxF "$sev" || { echo 0; return; }
+            echo "$SEV_NORM" | grep -qxF "$sev" || { echo 0; return; }
             jq --arg s "$sev" '[.. | objects | select(has("Severity")) | select(.Severity==$s)] | length' "$JSON_FILE" 2>/dev/null || echo 0
           }
           CRITICAL=$(count_sev CRITICAL)
@@ -253,7 +273,7 @@ runs:
           **Target:** ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
           **Findings (${{ inputs.SEVERITIES }}):** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }} LOW=${{ steps.counts.outputs.low }}
 
-    - name: Re-raise findings failure
-      if: always() && steps.fail_check.outcome == 'failure'
+    - name: Re-raise scan or findings failure
+      if: always() && (steps.scan.outcome == 'failure' || steps.fail_check.outcome == 'failure')
       shell: bash
       run: exit 1

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -69,6 +69,9 @@ outputs:
   low:
     description: 'Number of LOW findings'
     value: ${{ steps.counts.outputs.low }}
+  unknown:
+    description: 'Number of UNKNOWN findings'
+    value: ${{ steps.counts.outputs.unknown }}
   json_file:
     description: 'Filename of the Trivy JSON report (relative to the workspace), for use with trivy-claude-analysis in the same job'
     value: ${{ steps.defaults.outputs.json_file }}
@@ -109,16 +112,40 @@ runs:
           echo "::error::IMAGE_REF is required when SCAN_TYPE=image"
           exit 2
         fi
+        # Whitelist of Trivy severity levels (mirrors the GitLab sister component).
+        # Tokens are normalized (trim + uppercase) before comparison, so
+        # "HIGH, CRITICAL" and "high" are accepted.
+        VALID_SEVS=" UNKNOWN LOW MEDIUM HIGH CRITICAL "
+        if [ -z "$SEVERITIES_IN" ]; then
+          echo "::error::SEVERITIES must not be empty (allowed: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL)"
+          exit 2
+        fi
+        SEV_LIST=$(echo "$SEVERITIES_IN" | tr ',' '\n' | sed 's/[[:space:]]//g' | tr '[:lower:]' '[:upper:]')
+        for sev in $SEV_LIST; do
+          case "$VALID_SEVS" in
+            *" $sev "*) ;;
+            *)
+              echo "::error::SEVERITIES contains invalid value '$sev' (allowed: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL)"
+              exit 2
+              ;;
+          esac
+        done
         # Trivy filters scan output by SEVERITIES, so any severity in
         # FAIL_ON_SEVERITIES that is not in SEVERITIES would be silently
         # ignored by the fail-check step. Reject contradictory configs early.
         if [ -n "$FAIL_ON_SEVERITIES_IN" ]; then
-          SEV_LIST=$(echo "$SEVERITIES_IN" | tr ',' '\n' | sed 's/[[:space:]]//g')
-          for sev in $(echo "$FAIL_ON_SEVERITIES_IN" | tr ',' ' '); do
-            sev_trim=$(echo "$sev" | tr -d '[:space:]')
-            [ -z "$sev_trim" ] && continue
-            if ! echo "$SEV_LIST" | grep -qxF "$sev_trim"; then
-              echo "::error::FAIL_ON_SEVERITIES contains '$sev_trim' which is not in SEVERITIES='$SEVERITIES_IN'. FAIL_ON_SEVERITIES must be a subset of SEVERITIES, otherwise findings at that severity are filtered out at scan time and silently ignored by the fail check."
+          for sev_raw in $(echo "$FAIL_ON_SEVERITIES_IN" | tr ',' ' '); do
+            sev=$(echo "$sev_raw" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+            [ -z "$sev" ] && continue
+            case "$VALID_SEVS" in
+              *" $sev "*) ;;
+              *)
+                echo "::error::FAIL_ON_SEVERITIES contains invalid value '$sev' (allowed: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL)"
+                exit 2
+                ;;
+            esac
+            if ! echo "$SEV_LIST" | grep -qxF "$sev"; then
+              echo "::error::FAIL_ON_SEVERITIES contains '$sev' which is not in SEVERITIES='$SEVERITIES_IN'. FAIL_ON_SEVERITIES must be a subset of SEVERITIES, otherwise findings at that severity are filtered out at scan time and silently ignored by the fail check."
               exit 2
             fi
           done
@@ -187,27 +214,32 @@ runs:
         if ! command -v jq > /dev/null 2>&1; then
           sudo apt-get update -q && sudo apt-get install -y -q jq
         fi
-        CRITICAL=0; HIGH=0; MEDIUM=0; LOW=0
+        UNKNOWN=0; LOW=0; MEDIUM=0; HIGH=0; CRITICAL=0
+        COUNTS_STR=""
         if [ -f "$JSON_FILE" ]; then
           # Normalize SEVERITIES once: split, strip whitespace, uppercase.
-          # Trivy's JSON .Severity is always uppercase, so $sev is passed
-          # to jq as-is (callers below use uppercase tokens).
+          # Trivy's JSON .Severity is always uppercase, so $SEV is passed to jq as-is.
           SEV_NORM=$(echo "$SEVERITIES" | tr ',' '\n' | sed 's/[[:space:]]//g' | tr '[:lower:]' '[:upper:]')
-          count_sev() {
-            local sev="$1"
-            echo "$SEV_NORM" | grep -qxF "$sev" || { echo 0; return; }
-            jq --arg s "$sev" '[.. | objects | select(has("Severity")) | select(.Severity==$s)] | length' "$JSON_FILE" 2>/dev/null || echo 0
-          }
-          CRITICAL=$(count_sev CRITICAL)
-          HIGH=$(count_sev HIGH)
-          MEDIUM=$(count_sev MEDIUM)
-          LOW=$(count_sev LOW)
+          for SEV in $SEV_NORM; do
+            [ -z "$SEV" ] && continue
+            C=$(jq --arg s "$SEV" '[.. | objects | select(has("Severity")) | select(.Severity==$s)] | length' "$JSON_FILE" 2>/dev/null || echo 0)
+            case "$SEV" in
+              UNKNOWN)  UNKNOWN=$C ;;
+              LOW)      LOW=$C ;;
+              MEDIUM)   MEDIUM=$C ;;
+              HIGH)     HIGH=$C ;;
+              CRITICAL) CRITICAL=$C ;;
+            esac
+            COUNTS_STR="${COUNTS_STR}${SEV}=${C} "
+          done
         fi
+        echo "unknown=$UNKNOWN"   >> "$GITHUB_OUTPUT"
+        echo "low=$LOW"           >> "$GITHUB_OUTPUT"
+        echo "medium=$MEDIUM"     >> "$GITHUB_OUTPUT"
+        echo "high=$HIGH"         >> "$GITHUB_OUTPUT"
         echo "critical=$CRITICAL" >> "$GITHUB_OUTPUT"
-        echo "high=$HIGH" >> "$GITHUB_OUTPUT"
-        echo "medium=$MEDIUM" >> "$GITHUB_OUTPUT"
-        echo "low=$LOW" >> "$GITHUB_OUTPUT"
-        echo "Findings (within SEVERITIES=$SEVERITIES): CRITICAL=$CRITICAL HIGH=$HIGH MEDIUM=$MEDIUM LOW=$LOW"
+        echo "counts_str=${COUNTS_STR}" >> "$GITHUB_OUTPUT"
+        echo "Findings (within SEVERITIES=$SEVERITIES): ${COUNTS_STR:-none}"
 
     - name: Upload SARIF to Code Scanning
       if: always() && inputs.UPLOAD_SARIF == 'true' && hashFiles(steps.defaults.outputs.sarif_file) != ''
@@ -271,7 +303,7 @@ runs:
           **Branch:** ${{ github.ref_name }}
           **Commit:** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
           **Target:** ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
-          **Findings (${{ inputs.SEVERITIES }}):** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }} LOW=${{ steps.counts.outputs.low }}
+          **Findings (${{ inputs.SEVERITIES }}):** ${{ steps.counts.outputs.counts_str || 'none' }}
 
     - name: Re-raise scan or findings failure
       if: always() && (steps.scan.outcome == 'failure' || steps.fail_check.outcome == 'failure')

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -281,7 +281,7 @@ runs:
           echo "::warning::JSON report not found; cannot evaluate FAIL_ON_SEVERITIES."
           exit 0
         fi
-        SEVS_JSON=$(echo "$FAIL_ON_SEVERITIES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R . | jq -s .)
+        SEVS_JSON=$(echo "$FAIL_ON_SEVERITIES" | tr ',' '\n' | sed 's/[[:space:]]//g' | tr '[:lower:]' '[:upper:]' | grep -v '^$' | jq -R . | jq -s .)
         FAIL_COUNT=$(jq --argjson sevs "$SEVS_JSON" \
           '[.. | objects | select(has("Severity")) | select(.Severity as $s | $sevs | index($s) != null)] | length' \
           "$JSON_FILE" 2>/dev/null || echo 0)

--- a/trivy-scan-notify/action.yml
+++ b/trivy-scan-notify/action.yml
@@ -12,18 +12,18 @@ inputs:
     description: 'Filesystem path to scan (used when SCAN_TYPE=fs or config)'
     required: false
     default: '.'
-  SEVERITY:
-    description: 'Comma-separated severity levels to report'
+  SEVERITIES:
+    description: 'Comma-separated severity levels to include in all outputs (SARIF, notification, counts)'
     required: false
-    default: 'HIGH,CRITICAL'
+    default: 'CRITICAL,HIGH,MEDIUM,LOW'
+  FAIL_ON_SEVERITIES:
+    description: 'Comma-separated severity levels that trigger job failure. Leave empty to enable report-only mode.'
+    required: false
+    default: 'CRITICAL,HIGH'
   SCANNERS:
     description: 'Comma-separated list of Trivy scanners. If empty, a sensible default is picked per SCAN_TYPE (image=vuln,secret,misconfig ; fs=vuln,secret ; config=secret,misconfig)'
     required: false
     default: ''
-  EXIT_CODE:
-    description: 'Exit code to use when findings match SEVERITY (set to 0 during bootstrap to only report)'
-    required: false
-    default: '1'
   IGNORE_UNFIXED:
     description: 'Ignore vulnerabilities without a known fix'
     required: false
@@ -66,6 +66,9 @@ outputs:
   medium:
     description: 'Number of MEDIUM findings'
     value: ${{ steps.counts.outputs.medium }}
+  low:
+    description: 'Number of LOW findings'
+    value: ${{ steps.counts.outputs.low }}
   json_file:
     description: 'Filename of the Trivy JSON report (relative to the workspace), for use with trivy-claude-analysis in the same job'
     value: ${{ steps.defaults.outputs.json_file }}
@@ -124,9 +127,9 @@ runs:
         scan-ref: ${{ inputs.SCAN_TYPE == 'image' && '' || inputs.SCAN_REF }}
         format: sarif
         output: ${{ steps.defaults.outputs.sarif_file }}
-        severity: ${{ inputs.SEVERITY }}
+        severity: ${{ inputs.SEVERITIES }}
         scanners: ${{ steps.defaults.outputs.scanners }}
-        exit-code: ${{ inputs.EXIT_CODE }}
+        exit-code: '0'
         ignore-unfixed: ${{ inputs.IGNORE_UNFIXED }}
         trivyignores: ${{ inputs.TRIVYIGNORES }}
         cache: 'true'
@@ -146,7 +149,7 @@ runs:
         scan-ref: ${{ inputs.SCAN_TYPE == 'image' && '' || inputs.SCAN_REF }}
         format: json
         output: ${{ steps.defaults.outputs.json_file }}
-        severity: 'LOW,MEDIUM,HIGH,CRITICAL'
+        severity: ${{ inputs.SEVERITIES }}
         scanners: ${{ steps.defaults.outputs.scanners }}
         exit-code: '0'
         ignore-unfixed: ${{ inputs.IGNORE_UNFIXED }}
@@ -162,22 +165,29 @@ runs:
       id: counts
       env:
         JSON_FILE: ${{ steps.defaults.outputs.json_file }}
+        SEVERITIES: ${{ inputs.SEVERITIES }}
       shell: bash
       run: |
         if ! command -v jq > /dev/null 2>&1; then
           sudo apt-get update -q && sudo apt-get install -y -q jq
         fi
-        CRITICAL=0; HIGH=0; MEDIUM=0
+        CRITICAL=0; HIGH=0; MEDIUM=0; LOW=0
         if [ -f "$JSON_FILE" ]; then
-          # Vulnerabilities + misconfigurations + secrets all carry a Severity field
-          CRITICAL=$(jq '[.. | objects | select(has("Severity")) | select(.Severity=="CRITICAL")] | length' "$JSON_FILE" 2>/dev/null || echo 0)
-          HIGH=$(jq '[.. | objects | select(has("Severity")) | select(.Severity=="HIGH")] | length' "$JSON_FILE" 2>/dev/null || echo 0)
-          MEDIUM=$(jq '[.. | objects | select(has("Severity")) | select(.Severity=="MEDIUM")] | length' "$JSON_FILE" 2>/dev/null || echo 0)
+          count_sev() {
+            local sev="$1"
+            echo "$SEVERITIES" | tr ',' '\n' | grep -qxF "$sev" || { echo 0; return; }
+            jq --arg s "$sev" '[.. | objects | select(has("Severity")) | select(.Severity==$s)] | length' "$JSON_FILE" 2>/dev/null || echo 0
+          }
+          CRITICAL=$(count_sev CRITICAL)
+          HIGH=$(count_sev HIGH)
+          MEDIUM=$(count_sev MEDIUM)
+          LOW=$(count_sev LOW)
         fi
         echo "critical=$CRITICAL" >> "$GITHUB_OUTPUT"
         echo "high=$HIGH" >> "$GITHUB_OUTPUT"
         echo "medium=$MEDIUM" >> "$GITHUB_OUTPUT"
-        echo "Findings: CRITICAL=$CRITICAL HIGH=$HIGH MEDIUM=$MEDIUM"
+        echo "low=$LOW" >> "$GITHUB_OUTPUT"
+        echo "Findings (within SEVERITIES=$SEVERITIES): CRITICAL=$CRITICAL HIGH=$HIGH MEDIUM=$MEDIUM LOW=$LOW"
 
     - name: Upload SARIF to Code Scanning
       if: always() && inputs.UPLOAD_SARIF == 'true' && hashFiles(steps.defaults.outputs.sarif_file) != ''
@@ -202,23 +212,48 @@ runs:
         path: ${{ steps.defaults.outputs.json_file }}
         retention-days: 14
 
+    - name: Fail on severity findings
+      if: always()
+      id: fail_check
+      continue-on-error: true
+      env:
+        JSON_FILE: ${{ steps.defaults.outputs.json_file }}
+        FAIL_ON_SEVERITIES: ${{ inputs.FAIL_ON_SEVERITIES }}
+      shell: bash
+      run: |
+        if [ -z "$FAIL_ON_SEVERITIES" ]; then
+          echo "FAIL_ON_SEVERITIES is empty — report-only mode, not failing."
+          exit 0
+        fi
+        if [ ! -f "$JSON_FILE" ]; then
+          echo "::warning::JSON report not found; cannot evaluate FAIL_ON_SEVERITIES."
+          exit 0
+        fi
+        SEVS_JSON=$(echo "$FAIL_ON_SEVERITIES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R . | jq -s .)
+        FAIL_COUNT=$(jq --argjson sevs "$SEVS_JSON" \
+          '[.. | objects | select(has("Severity")) | select(.Severity as $s | $sevs | index($s) != null)] | length' \
+          "$JSON_FILE" 2>/dev/null || echo 0)
+        if [ "$FAIL_COUNT" -gt 0 ]; then
+          echo "::error::Trivy found $FAIL_COUNT finding(s) matching FAIL_ON_SEVERITIES=$FAIL_ON_SEVERITIES (see Code Scanning tab)."
+          exit 1
+        fi
+        echo "No findings at severity level(s): $FAIL_ON_SEVERITIES"
+
     - name: Notify on Mattermost
       if: always()
       uses: imio/gha/mattermost-notify@v7
       with:
         MATTERMOST_WEBHOOK_URL: ${{ inputs.MATTERMOST_WEBHOOK_URL }}
-        STATUS: ${{ steps.scan.outcome == 'success' && 'success' || 'failure' }}
+        STATUS: ${{ (steps.scan.outcome == 'failure' || steps.fail_check.outcome == 'failure') && 'failure' || 'success' }}
         TITLE: "Trivy Scan (${{ inputs.SCAN_TYPE }})"
         BODY: |
           **Repository:** [${{ github.repository }}](${{ github.server_url }}/${{ github.repository }})
           **Branch:** ${{ github.ref_name }}
           **Commit:** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
           **Target:** ${{ inputs.SCAN_TYPE == 'image' && inputs.IMAGE_REF || inputs.SCAN_REF }}
-          **Findings:** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }}
+          **Findings (${{ inputs.SEVERITIES }}):** CRITICAL=${{ steps.counts.outputs.critical }} HIGH=${{ steps.counts.outputs.high }} MEDIUM=${{ steps.counts.outputs.medium }} LOW=${{ steps.counts.outputs.low }}
 
-    - name: Re-raise scan failure
-      if: steps.scan.outcome == 'failure' && inputs.EXIT_CODE != '0'
+    - name: Re-raise findings failure
+      if: always() && steps.fail_check.outcome == 'failure'
       shell: bash
-      run: |
-        echo "::error::Trivy scan reported findings at or above the configured severity (see Code Scanning tab)."
-        exit 1
+      run: exit 1


### PR DESCRIPTION
Replace the single SEVERITY+EXIT_CODE pair with two independent inputs:
- SEVERITIES: controls which findings appear in all outputs (SARIF, JSON, notification counts). Defaults to HIGH,CRITICAL.
- FAIL_ON_SEVERITIES: controls which severities trigger job failure. Leaving it empty enables report-only mode (never blocks the pipeline).

Breaking changes:
- SEVERITY input renamed to SEVERITIES
- EXIT_CODE input removed

Also adds a `low` output and updates README and CHANGELOG for v8.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed SEVERITY → SEVERITIES; SEVERITIES cannot be empty.
  * Removed EXIT_CODE; replaced by FAIL_ON_SEVERITIES (empty = report-only).
  * FAIL_ON_SEVERITIES must be a subset of SEVERITIES; invalid combos fail early.

* **New Features**
  * low and unknown severity outputs added; counts are scoped to SEVERITIES.
  * SARIF/JSON results and notifications now filter to selected SEVERITIES.
  * Notifications/status reflect both scan failures and FAIL_ON_SEVERITIES breaches.

* **Documentation**
  * README and changelog updated with examples and behavior notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/gha/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->